### PR TITLE
fix: add missing celo offchain support

### DIFF
--- a/src/offchain/index.ts
+++ b/src/offchain/index.ts
@@ -10,3 +10,4 @@ export * from './xrp';
 export * from './xlm';
 export * from './tron';
 export * from './xdc';
+export * from './celo';


### PR DESCRIPTION
Might want to also double check and see if any other chains are missing from the exports.