### PR TITLE
export multiToken functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export * from './transaction';
 export * from './record';
 export * from './constants';
 export * from './nft';
+export * from './multiToken';


### PR DESCRIPTION
Right now these aren't exported, and you have to directly reference the file to use them