### PR TITLE
add currency KCC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "1.29.19",
+  "version": "1.29.20",
   "description": "Tatum API client allows browsers and Node.js clients to interact with Tatum API.",
   "main": "dist/src/index.js",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/model/request/Currency.ts
+++ b/src/model/request/Currency.ts
@@ -67,6 +67,7 @@ export enum Currency {
     QTUM = 'QTUM',
     EGLD = 'EGLD',
     ALGO = 'ALGO',
+    KCS = 'KCS',
 }
 
 export const ERC20_CURRENCIES = [


### PR DESCRIPTION
When I use the submodule KCC in core-api, I am getting errors of crashing currency models with @tatumio/tatum.
It seems that others are using the mainjs.
When we change all of the core-api with submodules, I think such things should be considered.