### PR TITLE
Feature/plt 397 sdk paths

### DIFF
--- a/examples/algo-example/src/app/algo.tx.example.ts
+++ b/examples/algo-example/src/app/algo.tx.example.ts
@@ -21,7 +21,7 @@ export async function algoTxWithPrivateKeyExample(): Promise<void> {
     account: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
   })
 
-  const preparedDeployNFTTransaction = await algoSDK.transaction.prepare.createNFTSignedTransaction({
+  const preparedDeployNFTTransaction = await algoSDK.erc721.prepare.createNFTSignedTransaction({
     fromPrivateKey:
       '72TCV5BRQPBMSAFPYO3CPWVDBYWNGAYNMTW5QHENOMQF7I6QLNMJWCJZ7A3V5YKD7QD6ZZPEHG2PV2ZVVEDDO6BCRGXWIL3DIUMSUCI',
     name: 'SomeArt',
@@ -29,7 +29,7 @@ export async function algoTxWithPrivateKeyExample(): Promise<void> {
     url: 'google.com',
   })
 
-  const sentDeployNFTTransaction = await algoSDK.transaction.send.createNFTSignedTransaction({
+  const sentDeployNFTTransaction = await algoSDK.erc721.send.createNFTSignedTransaction({
     fromPrivateKey:
       '72TCV5BRQPBMSAFPYO3CPWVDBYWNGAYNMTW5QHENOMQF7I6QLNMJWCJZ7A3V5YKD7QD6ZZPEHG2PV2ZVVEDDO6BCRGXWIL3DIUMSUCI',
     name: 'SomeArt',
@@ -37,7 +37,7 @@ export async function algoTxWithPrivateKeyExample(): Promise<void> {
     url: 'google.com',
   })
 
-  const preparedTransferSignedTransaction = await algoSDK.transaction.prepare.transferNFTSignedTransaction({
+  const preparedTransferSignedTransaction = await algoSDK.erc721.prepare.transferNFTSignedTransaction({
     fromPrivateKey:
       '72TCV5BRQPBMSAFPYO3CPWVDBYWNGAYNMTW5QHENOMQF7I6QLNMJWCJZ7A3V5YKD7QD6ZZPEHG2PV2ZVVEDDO6BCRGXWIL3DIUMSUCI',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -45,7 +45,7 @@ export async function algoTxWithPrivateKeyExample(): Promise<void> {
     tokenId: '453453',
   })
 
-  const sentTransferSignedTransaction = await algoSDK.transaction.send.transferNFTSignedTransaction({
+  const sentTransferSignedTransaction = await algoSDK.erc721.send.transferNFTSignedTransaction({
     fromPrivateKey:
       '72TCV5BRQPBMSAFPYO3CPWVDBYWNGAYNMTW5QHENOMQF7I6QLNMJWCJZ7A3V5YKD7QD6ZZPEHG2PV2ZVVEDDO6BCRGXWIL3DIUMSUCI',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -53,14 +53,14 @@ export async function algoTxWithPrivateKeyExample(): Promise<void> {
     tokenId: '453453',
   })
 
-  const preparedMintSignedTransaction = await algoSDK.transaction.prepare.burnNFTSignedTransaction({
+  const preparedMintSignedTransaction = await algoSDK.erc721.prepare.burnNFTSignedTransaction({
     fromPrivateKey:
       '72TCV5BRQPBMSAFPYO3CPWVDBYWNGAYNMTW5QHENOMQF7I6QLNMJWCJZ7A3V5YKD7QD6ZZPEHG2PV2ZVVEDDO6BCRGXWIL3DIUMSUCI',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
     tokenId: '453453',
   })
 
-  const sentMintSignedTransaction = await algoSDK.transaction.send.burnNFTSignedTransaction({
+  const sentMintSignedTransaction = await algoSDK.erc721.send.burnNFTSignedTransaction({
     fromPrivateKey:
       '72TCV5BRQPBMSAFPYO3CPWVDBYWNGAYNMTW5QHENOMQF7I6QLNMJWCJZ7A3V5YKD7QD6ZZPEHG2PV2ZVVEDDO6BCRGXWIL3DIUMSUCI',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -85,7 +85,7 @@ export async function algoTxWithSignatureIdExample(): Promise<void> {
     from: '687422eEA2cB73B5d3e242bA5456b782919AFc85',
   })
 
-  const preparedDeployNFTTransaction = await algoSDK.transaction.prepare.createNFTSignedTransaction({
+  const preparedDeployNFTTransaction = await algoSDK.erc721.prepare.createNFTSignedTransaction({
     signatureId: '26d3883e-4e17-48b3-a0ee-09a3e484ac83',
     from: '687422eEA2cB73B5d3e242bA5456b782919AFc85',
     name: 'SomeArt',
@@ -93,7 +93,7 @@ export async function algoTxWithSignatureIdExample(): Promise<void> {
     url: 'google.com',
   })
 
-  const sentDeployNFTTransaction = await algoSDK.transaction.send.createNFTSignedTransaction({
+  const sentDeployNFTTransaction = await algoSDK.erc721.send.createNFTSignedTransaction({
     signatureId: '26d3883e-4e17-48b3-a0ee-09a3e484ac83',
     from: '687422eEA2cB73B5d3e242bA5456b782919AFc85',
     name: 'SomeArt',
@@ -101,7 +101,7 @@ export async function algoTxWithSignatureIdExample(): Promise<void> {
     url: 'google.com',
   })
 
-  const preparedTransferSignedTransaction = await algoSDK.transaction.prepare.transferNFTSignedTransaction({
+  const preparedTransferSignedTransaction = await algoSDK.erc721.prepare.transferNFTSignedTransaction({
     signatureId: '26d3883e-4e17-48b3-a0ee-09a3e484ac83',
     from: '687422eEA2cB73B5d3e242bA5456b782919AFc85',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -109,7 +109,7 @@ export async function algoTxWithSignatureIdExample(): Promise<void> {
     tokenId: '453453',
   })
 
-  const sentTransferSignedTransaction = await algoSDK.transaction.send.transferNFTSignedTransaction({
+  const sentTransferSignedTransaction = await algoSDK.erc721.send.transferNFTSignedTransaction({
     signatureId: '26d3883e-4e17-48b3-a0ee-09a3e484ac83',
     from: '687422eEA2cB73B5d3e242bA5456b782919AFc85',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -117,14 +117,14 @@ export async function algoTxWithSignatureIdExample(): Promise<void> {
     tokenId: '453453',
   })
 
-  const preparedMintSignedTransaction = await algoSDK.transaction.prepare.burnNFTSignedTransaction({
+  const preparedMintSignedTransaction = await algoSDK.erc721.prepare.burnNFTSignedTransaction({
     signatureId: '26d3883e-4e17-48b3-a0ee-09a3e484ac83',
     from: '687422eEA2cB73B5d3e242bA5456b782919AFc85',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
     tokenId: '453453',
   })
 
-  const sentMintSignedTransaction = await algoSDK.transaction.send.burnNFTSignedTransaction({
+  const sentMintSignedTransaction = await algoSDK.erc721.send.burnNFTSignedTransaction({
     signatureId: '26d3883e-4e17-48b3-a0ee-09a3e484ac83',
     from: '687422eEA2cB73B5d3e242bA5456b782919AFc85',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',

--- a/examples/bsc-example/src/app/bsc.tx.example.ts
+++ b/examples/bsc-example/src/app/bsc.tx.example.ts
@@ -167,75 +167,71 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await bscSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'BSC',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await bscSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'BSC',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await bscSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'BSC',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await bscSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'BSC',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await bscSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'BSC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await bscSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'BSC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await bscSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'BSC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await bscSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'BSC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await bscSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -269,8 +265,8 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedMintProvenanceSignedTransaction =
-    await bscSDK.erc721.prepare.mintProvenanceSignedTransaction({
+  const preparedMintProvenanceSignedTransaction = await bscSDK.erc721.prepare.mintProvenanceSignedTransaction(
+    {
       chain: 'BSC',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -282,22 +278,22 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintProvenanceSignedTransaction =
-    await bscSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'BSC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await bscSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'BSC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await bscSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -331,20 +327,18 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await bscSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'BSC',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await bscSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'BSC',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await bscSDK.erc721.send.transferSignedTransaction({
     chain: 'BSC',
@@ -413,29 +407,26 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
 
-  const preparedDeployMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'BSC',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await bscSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'BSC',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await bscSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'BSC',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await bscSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'BSC',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'BSC',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await bscSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'BSC',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await bscSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -456,35 +447,34 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await bscSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'BSC',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await bscSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'BSC',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await bscSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
       amount: '10',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await bscSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'BSC',
-      tokenId: '123',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await bscSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'BSC',
+    tokenId: '123',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await bscSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -506,15 +496,14 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'BSC',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const preparedBurnMultiTokenTransaction = await bscSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'BSC',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   const sentBurnMultiTokenTransaction = await bscSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'BSC',
@@ -535,15 +524,14 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await bscSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'BSC',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const sentMintBurnTokenBatchTransaction = await bscSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'BSC',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
@@ -716,75 +704,71 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await bscSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'BSC',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await bscSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'BSC',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await bscSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'BSC',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await bscSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'BSC',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await bscSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'BSC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await bscSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'BSC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await bscSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'BSC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await bscSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'BSC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await bscSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -818,8 +802,8 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedMintProvenanceSignedTransaction =
-    await bscSDK.erc721.prepare.mintProvenanceSignedTransaction({
+  const preparedMintProvenanceSignedTransaction = await bscSDK.erc721.prepare.mintProvenanceSignedTransaction(
+    {
       chain: 'BSC',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -831,22 +815,22 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintProvenanceSignedTransaction =
-    await bscSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'BSC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await bscSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'BSC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await bscSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -880,20 +864,18 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await bscSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'BSC',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await bscSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'BSC',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await bscSDK.erc721.send.transferSignedTransaction({
     chain: 'BSC',
@@ -961,29 +943,26 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'BSC',
-      fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await bscSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'BSC',
+    fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await bscSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'BSC',
-      fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await bscSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'BSC',
+    fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'BSC',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await bscSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'BSC',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await bscSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -1004,35 +983,34 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await bscSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'BSC',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await bscSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'BSC',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await bscSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
       amount: '10',
       fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await bscSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'BSC',
-      tokenId: '123',
-      amount: '10',
-      fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await bscSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'BSC',
+    tokenId: '123',
+    amount: '10',
+    fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await bscSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -1054,15 +1032,14 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await bscSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'BSC',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const preparedBurnMultiTokenTransaction = await bscSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'BSC',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   const sentBurnMultiTokenTransaction = await bscSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'BSC',
@@ -1083,15 +1060,14 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await bscSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'BSC',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const sentMintBurnTokenBatchTransaction = await bscSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'BSC',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =

--- a/examples/bsc-example/src/app/bsc.tx.example.ts
+++ b/examples/bsc-example/src/app/bsc.tx.example.ts
@@ -5,7 +5,7 @@ const bscSDK = TatumBscSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function bscTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction = await bscSDK.transaction.native.prepare.transferSignedTransaction({
+  const preparedTransferNativeTransaction = await bscSDK.transaction.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -16,7 +16,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentTransferNativeTransaction = await bscSDK.transaction.native.send.transferSignedTransaction({
+  const sentTransferNativeTransaction = await bscSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -28,7 +28,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await bscSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await bscSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -43,7 +43,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await bscSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await bscSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -58,7 +58,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await bscSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await bscSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -71,7 +71,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await bscSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await bscSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -84,7 +84,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await bscSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await bscSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -92,7 +92,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await bscSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await bscSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -100,14 +100,14 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await bscSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await bscSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await bscSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await bscSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -115,7 +115,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await bscSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await bscSDK.erc721.prepare.deploySignedTransaction({
     chain: 'BSC',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -127,7 +127,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await bscSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await bscSDK.erc721.send.deploySignedTransaction({
     chain: 'BSC',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -139,7 +139,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await bscSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await bscSDK.erc721.prepare.mintSignedTransaction({
     chain: 'BSC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -153,7 +153,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await bscSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await bscSDK.erc721.send.mintSignedTransaction({
     chain: 'BSC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -168,7 +168,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await bscSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -187,7 +187,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await bscSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -206,7 +206,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await bscSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'BSC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -222,7 +222,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await bscSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'BSC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -238,7 +238,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await bscSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'BSC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -254,7 +254,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await bscSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'BSC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -270,7 +270,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await bscSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'BSC',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -285,7 +285,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await bscSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'BSC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -300,7 +300,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await bscSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -316,7 +316,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await bscSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -331,7 +331,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await bscSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await bscSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'BSC',
       tokenId: '453453',
@@ -346,7 +346,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await bscSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await bscSDK.erc721.send.transferSignedTransaction({
     chain: 'BSC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -360,7 +360,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await bscSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'BSC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -374,7 +374,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await bscSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await bscSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'BSC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -387,7 +387,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await bscSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await bscSDK.erc721.prepare.burnSignedTransaction({
     chain: 'BSC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -399,7 +399,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await bscSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await bscSDK.erc721.send.burnSignedTransaction({
     chain: 'BSC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -414,21 +414,21 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
   // ERC1155(MULTI TOKEN)
 
   const preparedDeployMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'BSC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await bscSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'BSC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
@@ -437,7 +437,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await bscSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await bscSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'BSC',
     tokenId: '123',
@@ -447,7 +447,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await bscSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'BSC',
       tokenId: [['123'], ['321']],
@@ -457,7 +457,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await bscSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'BSC',
       tokenId: [['123'], ['321']],
@@ -467,7 +467,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
@@ -477,7 +477,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await bscSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
@@ -487,7 +487,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await bscSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: ['123', '321'],
@@ -497,7 +497,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await bscSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: ['123', '321'],
@@ -507,7 +507,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'BSC',
       tokenId: '123',
       amount: '1',
@@ -516,7 +516,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentBurnMultiTokenTransaction = await bscSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await bscSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'BSC',
     tokenId: '123',
     amount: '1',
@@ -526,7 +526,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await bscSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'BSC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -536,7 +536,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await bscSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'BSC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -547,7 +547,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await bscSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await bscSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'BSC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -561,7 +561,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await bscSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await bscSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'BSC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -577,7 +577,7 @@ export async function bscTxWithSignatureIdExample(): Promise<void> {
 
 export async function bscTxWithPrivateKeyExample(): Promise<void> {
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await bscSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await bscSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -592,7 +592,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await bscSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await bscSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -607,7 +607,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await bscSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await bscSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -620,7 +620,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await bscSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await bscSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -633,7 +633,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await bscSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await bscSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -641,7 +641,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await bscSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await bscSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -649,14 +649,14 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await bscSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await bscSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await bscSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await bscSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
@@ -664,7 +664,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await bscSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await bscSDK.erc721.prepare.deploySignedTransaction({
     chain: 'BSC',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -676,7 +676,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await bscSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await bscSDK.erc721.send.deploySignedTransaction({
     chain: 'BSC',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -688,7 +688,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await bscSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await bscSDK.erc721.prepare.mintSignedTransaction({
     chain: 'BSC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -702,7 +702,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await bscSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await bscSDK.erc721.send.mintSignedTransaction({
     chain: 'BSC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -717,7 +717,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await bscSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -736,7 +736,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await bscSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -755,7 +755,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await bscSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'BSC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -771,7 +771,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await bscSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'BSC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -787,7 +787,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await bscSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'BSC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -803,7 +803,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await bscSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'BSC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -819,7 +819,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await bscSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'BSC',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -834,7 +834,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await bscSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'BSC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -849,7 +849,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await bscSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -865,7 +865,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await bscSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await bscSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'BSC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -880,7 +880,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await bscSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await bscSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'BSC',
       tokenId: '453453',
@@ -895,7 +895,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await bscSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await bscSDK.erc721.send.transferSignedTransaction({
     chain: 'BSC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -909,7 +909,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await bscSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await bscSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'BSC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -923,7 +923,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await bscSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await bscSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'BSC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -936,7 +936,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await bscSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await bscSDK.erc721.prepare.burnSignedTransaction({
     chain: 'BSC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -948,7 +948,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await bscSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await bscSDK.erc721.send.burnSignedTransaction({
     chain: 'BSC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -962,21 +962,21 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'BSC',
       fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await bscSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'BSC',
       fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
@@ -985,7 +985,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await bscSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await bscSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'BSC',
     tokenId: '123',
@@ -995,7 +995,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await bscSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'BSC',
       tokenId: [['123'], ['321']],
@@ -1005,7 +1005,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await bscSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'BSC',
       tokenId: [['123'], ['321']],
@@ -1015,7 +1015,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
@@ -1025,7 +1025,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await bscSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: '123',
@@ -1035,7 +1035,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await bscSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: ['123', '321'],
@@ -1045,7 +1045,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await bscSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'BSC',
       tokenId: ['123', '321'],
@@ -1055,7 +1055,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await bscSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await bscSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'BSC',
       tokenId: '123',
       amount: '1',
@@ -1064,7 +1064,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentBurnMultiTokenTransaction = await bscSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await bscSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'BSC',
     tokenId: '123',
     amount: '1',
@@ -1074,7 +1074,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await bscSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'BSC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1084,7 +1084,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await bscSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await bscSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'BSC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1095,7 +1095,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await bscSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await bscSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'BSC',
       fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
       enableFungibleTokens: true,
@@ -1109,7 +1109,7 @@ export async function bscTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await bscSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await bscSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'BSC',
       fromPrivateKey: '0xc313f7e1303ce1c344df819d1d48c79a834c493c73e12b4389bfb50127c8aaa7',
       enableFungibleTokens: true,

--- a/examples/celo-example/src/app/celo.tx.example.ts
+++ b/examples/celo-example/src/app/celo.tx.example.ts
@@ -4,7 +4,7 @@ import { REPLACE_ME_WITH_TATUM_API_KEY } from '@tatumio/shared-testing-common'
 const celoSDK = TatumCeloSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function celoTxWithSignatureIdExample(): Promise<void> {
-  const preparedDeployErc721Transaction = await celoSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await celoSDK.erc721.prepare.deploySignedTransaction({
     chain: 'CELO',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -13,7 +13,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const sentDeployErc721Transaction = await celoSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await celoSDK.erc721.send.deploySignedTransaction({
     chain: 'CELO',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -22,7 +22,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const preparedMintSignedTransaction = await celoSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await celoSDK.erc721.prepare.mintSignedTransaction({
     chain: 'CELO',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -33,7 +33,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const sentMintSignedTransaction = await celoSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await celoSDK.erc721.send.mintSignedTransaction({
     chain: 'CELO',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -45,7 +45,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await celoSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -61,7 +61,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await celoSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -77,7 +77,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await celoSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'CELO',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -90,7 +90,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await celoSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'CELO',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -103,7 +103,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await celoSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'CELO',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -116,7 +116,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await celoSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'CELO',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -129,7 +129,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await celoSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'CELO',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -141,7 +141,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await celoSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'CELO',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -153,7 +153,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await celoSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -166,7 +166,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await celoSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -179,7 +179,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.transferSignedTransaction({
+    await celoSDK.erc721.prepare.transferSignedTransaction({
       chain: 'CELO',
       tokenId: '453453',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -189,7 +189,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentTransferSignedTransaction = await celoSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await celoSDK.erc721.send.transferSignedTransaction({
     chain: 'CELO',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -200,7 +200,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await celoSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'CELO',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -211,7 +211,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await celoSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await celoSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'CELO',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -221,7 +221,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const preparedBurnErc721Transaction = await celoSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await celoSDK.erc721.prepare.burnSignedTransaction({
     chain: 'CELO',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -230,7 +230,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const sentBurnErc721Transaction = await celoSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await celoSDK.erc721.send.burnSignedTransaction({
     chain: 'CELO',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -241,7 +241,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'CELO',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
@@ -249,7 +249,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentDeployMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await celoSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'CELO',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
@@ -257,7 +257,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: '123',
@@ -267,7 +267,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintMultiTokenTransaction = await celoSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await celoSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'CELO',
     tokenId: '123',
@@ -278,7 +278,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await celoSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'CELO',
       tokenId: [['123'], ['321']],
@@ -289,7 +289,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await celoSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'CELO',
       tokenId: [['123'], ['321']],
@@ -300,7 +300,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: '123',
@@ -311,7 +311,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await celoSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: '123',
@@ -322,7 +322,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await celoSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: ['123', '321'],
@@ -333,7 +333,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await celoSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: ['123', '321'],
@@ -344,7 +344,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'CELO',
       tokenId: '123',
       amount: '1',
@@ -354,7 +354,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentBurnMultiTokenTransaction = await celoSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await celoSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'CELO',
     tokenId: '123',
     amount: '1',
@@ -365,7 +365,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await celoSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'CELO',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -376,7 +376,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await celoSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'CELO',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -387,7 +387,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedCustodialWalletSignedTransaction =
-    await celoSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await celoSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'CELO',
       feeCurrency: 'CUSD',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -402,7 +402,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await celoSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await celoSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'CELO',
       feeCurrency: 'CUSD',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -418,7 +418,7 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
 }
 
 export async function celoTxWithPrivateKeyExample(): Promise<void> {
-  const preparedDeployErc721Transaction = await celoSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await celoSDK.erc721.prepare.deploySignedTransaction({
     chain: 'CELO',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -427,7 +427,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const sentDeployErc721Transaction = await celoSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await celoSDK.erc721.send.deploySignedTransaction({
     chain: 'CELO',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -436,7 +436,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const preparedMintSignedTransaction = await celoSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await celoSDK.erc721.prepare.mintSignedTransaction({
     chain: 'CELO',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -447,7 +447,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const sentMintSignedTransaction = await celoSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await celoSDK.erc721.send.mintSignedTransaction({
     chain: 'CELO',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -459,7 +459,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await celoSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -475,7 +475,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await celoSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -491,7 +491,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await celoSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'CELO',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -504,7 +504,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await celoSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'CELO',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -517,7 +517,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await celoSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'CELO',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -530,7 +530,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await celoSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'CELO',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -543,7 +543,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await celoSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'CELO',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -555,7 +555,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await celoSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'CELO',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -567,7 +567,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await celoSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -580,7 +580,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await celoSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await celoSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'CELO',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -593,7 +593,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.transferSignedTransaction({
+    await celoSDK.erc721.prepare.transferSignedTransaction({
       chain: 'CELO',
       tokenId: '453453',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -603,7 +603,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentTransferSignedTransaction = await celoSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await celoSDK.erc721.send.transferSignedTransaction({
     chain: 'CELO',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -614,7 +614,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await celoSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await celoSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'CELO',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -625,7 +625,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await celoSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await celoSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'CELO',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -635,7 +635,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const preparedBurnErc721Transaction = await celoSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await celoSDK.erc721.prepare.burnSignedTransaction({
     chain: 'CELO',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -644,7 +644,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const sentBurnErc721Transaction = await celoSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await celoSDK.erc721.send.burnSignedTransaction({
     chain: 'CELO',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -655,7 +655,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'CELO',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
@@ -663,7 +663,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentDeployMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await celoSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'CELO',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
@@ -671,7 +671,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: '123',
@@ -681,7 +681,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintMultiTokenTransaction = await celoSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await celoSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'CELO',
     tokenId: '123',
@@ -692,7 +692,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await celoSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'CELO',
       tokenId: [['123'], ['321']],
@@ -703,7 +703,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await celoSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'CELO',
       tokenId: [['123'], ['321']],
@@ -714,7 +714,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: '123',
@@ -724,7 +724,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await celoSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: '123',
@@ -734,7 +734,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await celoSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: ['123', '321'],
@@ -744,7 +744,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await celoSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'CELO',
       tokenId: ['123', '321'],
@@ -754,7 +754,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await celoSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await celoSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'CELO',
       tokenId: '123',
       amount: '1',
@@ -764,7 +764,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentBurnMultiTokenTransaction = await celoSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await celoSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'CELO',
     tokenId: '123',
     amount: '1',
@@ -775,7 +775,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await celoSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'CELO',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -786,7 +786,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await celoSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await celoSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'CELO',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -797,7 +797,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedCustodialWalletSignedTransaction =
-    await celoSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await celoSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'CELO',
       feeCurrency: 'CUSD',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
@@ -812,7 +812,7 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await celoSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await celoSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'CELO',
       feeCurrency: 'CUSD',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',

--- a/examples/celo-example/src/app/celo.tx.example.ts
+++ b/examples/celo-example/src/app/celo.tx.example.ts
@@ -44,63 +44,59 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await celoSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'CELO',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const preparedMintMultipleSignedTransaction = await celoSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'CELO',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await celoSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'CELO',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const sentMintMultipleSignedTransaction = await celoSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'CELO',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await celoSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'CELO',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const preparedMintCashbackSignedTransaction = await celoSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'CELO',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await celoSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'CELO',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const sentMintCashbackSignedTransaction = await celoSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'CELO',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await celoSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -140,17 +136,16 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintProvenanceSignedTransaction =
-    await celoSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'CELO',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const sentMintProvenanceSignedTransaction = await celoSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'CELO',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await celoSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -178,16 +173,15 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const preparedTransferSignedTransaction =
-    await celoSDK.erc721.prepare.transferSignedTransaction({
-      chain: 'CELO',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const preparedTransferSignedTransaction = await celoSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'CELO',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
   const sentTransferSignedTransaction = await celoSDK.erc721.send.transferSignedTransaction({
     chain: 'CELO',
@@ -240,32 +234,29 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await celoSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'CELO',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-      feeCurrency: 'CUSD',
-    })
+  const preparedDeployMultiTokenTransaction = await celoSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'CELO',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+    feeCurrency: 'CUSD',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await celoSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'CELO',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-      feeCurrency: 'CUSD',
-    })
+  const sentDeployMultiTokenTransaction = await celoSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'CELO',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+    feeCurrency: 'CUSD',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await celoSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'CELO',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      feeCurrency: 'CUSD',
-    })
+  const preparedMintMultiTokenTransaction = await celoSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'CELO',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    feeCurrency: 'CUSD',
+  })
 
   const sentMintMultiTokenTransaction = await celoSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -288,16 +279,15 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await celoSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'CELO',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      feeCurrency: 'CUSD',
-    })
+  const sentMintMultiTokenBatchTransaction = await celoSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'CELO',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    feeCurrency: 'CUSD',
+  })
 
   const preparedTransferMultiTokenTransaction =
     await celoSDK.multiToken.prepare.transferMultiTokenTransaction({
@@ -310,16 +300,15 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentTransferMultiTokenTransaction =
-    await celoSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'CELO',
-      tokenId: '123',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      feeCurrency: 'CUSD',
-    })
+  const sentTransferMultiTokenTransaction = await celoSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'CELO',
+    tokenId: '123',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    feeCurrency: 'CUSD',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await celoSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -343,16 +332,15 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await celoSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'CELO',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      feeCurrency: 'CUSD',
-    })
+  const preparedBurnMultiTokenTransaction = await celoSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'CELO',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    feeCurrency: 'CUSD',
+  })
 
   const sentBurnMultiTokenTransaction = await celoSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'CELO',
@@ -375,16 +363,15 @@ export async function celoTxWithSignatureIdExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await celoSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'CELO',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      feeCurrency: 'CUSD',
-    })
+  const sentMintBurnTokenBatchTransaction = await celoSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'CELO',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    feeCurrency: 'CUSD',
+  })
 
   const preparedCustodialWalletSignedTransaction =
     await celoSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
@@ -458,63 +445,59 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
     feeCurrency: 'CUSD',
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await celoSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'CELO',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const preparedMintMultipleSignedTransaction = await celoSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'CELO',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await celoSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'CELO',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const sentMintMultipleSignedTransaction = await celoSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'CELO',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await celoSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'CELO',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const preparedMintCashbackSignedTransaction = await celoSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'CELO',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await celoSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'CELO',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const sentMintCashbackSignedTransaction = await celoSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'CELO',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await celoSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -554,17 +537,16 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintProvenanceSignedTransaction =
-    await celoSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'CELO',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const sentMintProvenanceSignedTransaction = await celoSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'CELO',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await celoSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -592,16 +574,15 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const preparedTransferSignedTransaction =
-    await celoSDK.erc721.prepare.transferSignedTransaction({
-      chain: 'CELO',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-    })
+  const preparedTransferSignedTransaction = await celoSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'CELO',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+  })
 
   const sentTransferSignedTransaction = await celoSDK.erc721.send.transferSignedTransaction({
     chain: 'CELO',
@@ -654,32 +635,29 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await celoSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'CELO',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-      feeCurrency: 'CUSD',
-    })
+  const preparedDeployMultiTokenTransaction = await celoSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'CELO',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+    feeCurrency: 'CUSD',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await celoSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'CELO',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-      feeCurrency: 'CUSD',
-    })
+  const sentDeployMultiTokenTransaction = await celoSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'CELO',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+    feeCurrency: 'CUSD',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await celoSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'CELO',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      feeCurrency: 'CUSD',
-    })
+  const preparedMintMultiTokenTransaction = await celoSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'CELO',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    feeCurrency: 'CUSD',
+  })
 
   const sentMintMultiTokenTransaction = await celoSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -702,16 +680,15 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await celoSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'CELO',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      feeCurrency: 'CUSD',
-    })
+  const sentMintMultiTokenBatchTransaction = await celoSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'CELO',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    feeCurrency: 'CUSD',
+  })
 
   const preparedTransferMultiTokenTransaction =
     await celoSDK.multiToken.prepare.transferMultiTokenTransaction({
@@ -723,15 +700,14 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentTransferMultiTokenTransaction =
-    await celoSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'CELO',
-      tokenId: '123',
-      amount: '10',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await celoSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'CELO',
+    tokenId: '123',
+    amount: '10',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await celoSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -753,16 +729,15 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await celoSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'CELO',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      feeCurrency: 'CUSD',
-    })
+  const preparedBurnMultiTokenTransaction = await celoSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'CELO',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    feeCurrency: 'CUSD',
+  })
 
   const sentBurnMultiTokenTransaction = await celoSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'CELO',
@@ -785,16 +760,15 @@ export async function celoTxWithPrivateKeyExample(): Promise<void> {
       feeCurrency: 'CUSD',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await celoSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'CELO',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      feeCurrency: 'CUSD',
-    })
+  const sentMintBurnTokenBatchTransaction = await celoSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'CELO',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    feeCurrency: 'CUSD',
+  })
 
   const preparedCustodialWalletSignedTransaction =
     await celoSDK.custodial.prepare.generateCustodialWalletSignedTransaction({

--- a/examples/celo-example/src/app/celo.tx.example.ts
+++ b/examples/celo-example/src/app/celo.tx.example.ts
@@ -4,14 +4,13 @@ import { REPLACE_ME_WITH_TATUM_API_KEY } from '@tatumio/shared-testing-common'
 const celoSDK = TatumCeloSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function celoTxWithSignatureIdExample(): Promise<void> {
-  const preparedTransferNativeTransaction =
-    await celoSDK.transaction.prepare.transferSignedTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      feeCurrency: 'CUSD',
-      amount: '1',
-    })
+  const preparedTransferNativeTransaction = await celoSDK.transaction.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    feeCurrency: 'CUSD',
+    amount: '1',
+  })
 
   const sentTransferNativeTransaction = await celoSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',

--- a/examples/eth-example/src/app/eth.tx.example.ts
+++ b/examples/eth-example/src/app/eth.tx.example.ts
@@ -5,7 +5,7 @@ const ethSDK = TatumEthSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function ethTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction = await ethSDK.transaction.native.prepare.transferSignedTransaction({
+  const preparedTransferNativeTransaction = await ethSDK.transaction.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -16,7 +16,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentTransferNativeTransaction = await ethSDK.transaction.native.send.transferSignedTransaction({
+  const sentTransferNativeTransaction = await ethSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -28,7 +28,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await ethSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await ethSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -43,7 +43,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await ethSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await ethSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -58,7 +58,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await ethSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await ethSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -71,7 +71,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await ethSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await ethSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -84,7 +84,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await ethSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await ethSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -92,7 +92,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await ethSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await ethSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -100,14 +100,14 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await ethSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await ethSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await ethSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await ethSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -115,7 +115,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await ethSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await ethSDK.erc721.prepare.deploySignedTransaction({
     chain: 'ETH',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -127,7 +127,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await ethSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await ethSDK.erc721.send.deploySignedTransaction({
     chain: 'ETH',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -139,7 +139,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await ethSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await ethSDK.erc721.prepare.mintSignedTransaction({
     chain: 'ETH',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -153,7 +153,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await ethSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await ethSDK.erc721.send.mintSignedTransaction({
     chain: 'ETH',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -168,7 +168,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await ethSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -187,7 +187,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await ethSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -206,7 +206,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await ethSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'ETH',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -222,7 +222,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await ethSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'ETH',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -238,7 +238,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await ethSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'ETH',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -254,7 +254,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await ethSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'ETH',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -270,7 +270,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await ethSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'ETH',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -285,7 +285,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await ethSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'ETH',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -300,7 +300,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await ethSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -316,7 +316,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await ethSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -331,7 +331,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await ethSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await ethSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'ETH',
       tokenId: '453453',
@@ -346,7 +346,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await ethSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await ethSDK.erc721.send.transferSignedTransaction({
     chain: 'ETH',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -360,7 +360,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await ethSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'ETH',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -374,7 +374,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await ethSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await ethSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'ETH',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -387,7 +387,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await ethSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await ethSDK.erc721.prepare.burnSignedTransaction({
     chain: 'ETH',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -399,7 +399,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await ethSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await ethSDK.erc721.send.burnSignedTransaction({
     chain: 'ETH',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -413,21 +413,21 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'ETH',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await ethSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'ETH',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
@@ -436,7 +436,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await ethSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await ethSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'ETH',
     tokenId: '123',
@@ -446,7 +446,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await ethSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'ETH',
       tokenId: [['123'], ['321']],
@@ -456,7 +456,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await ethSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'ETH',
       tokenId: [['123'], ['321']],
@@ -466,7 +466,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
@@ -476,7 +476,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await ethSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
@@ -486,7 +486,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await ethSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: ['123', '321'],
@@ -496,7 +496,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await ethSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: ['123', '321'],
@@ -506,7 +506,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'ETH',
       tokenId: '123',
       amount: '1',
@@ -515,7 +515,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentBurnMultiTokenTransaction = await ethSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await ethSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ETH',
     tokenId: '123',
     amount: '1',
@@ -525,7 +525,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await ethSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'ETH',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -535,7 +535,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await ethSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'ETH',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -546,7 +546,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await ethSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await ethSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'ETH',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -560,7 +560,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await ethSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await ethSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'ETH',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -576,7 +576,7 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
 
 export async function ethTxWithPrivateKeyExample(): Promise<void> {
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await ethSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await ethSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -591,7 +591,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await ethSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await ethSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -606,7 +606,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await ethSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await ethSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -619,7 +619,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await ethSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await ethSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -632,7 +632,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await ethSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await ethSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -640,7 +640,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await ethSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await ethSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -648,14 +648,14 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await ethSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await ethSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await ethSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await ethSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
@@ -663,7 +663,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await ethSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await ethSDK.erc721.prepare.deploySignedTransaction({
     chain: 'ETH',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -675,7 +675,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await ethSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await ethSDK.erc721.send.deploySignedTransaction({
     chain: 'ETH',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -687,7 +687,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await ethSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await ethSDK.erc721.prepare.mintSignedTransaction({
     chain: 'ETH',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -701,7 +701,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await ethSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await ethSDK.erc721.send.mintSignedTransaction({
     chain: 'ETH',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -716,7 +716,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await ethSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -735,7 +735,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await ethSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -754,7 +754,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await ethSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'ETH',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -770,7 +770,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await ethSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'ETH',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -786,7 +786,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await ethSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'ETH',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -802,7 +802,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await ethSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'ETH',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -818,7 +818,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await ethSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'ETH',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -833,7 +833,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await ethSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'ETH',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -848,7 +848,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await ethSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -864,7 +864,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await ethSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await ethSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'ETH',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -879,7 +879,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await ethSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await ethSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'ETH',
       tokenId: '453453',
@@ -894,7 +894,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await ethSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await ethSDK.erc721.send.transferSignedTransaction({
     chain: 'ETH',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -908,7 +908,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await ethSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await ethSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'ETH',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -922,7 +922,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await ethSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await ethSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'ETH',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -935,7 +935,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await ethSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await ethSDK.erc721.prepare.burnSignedTransaction({
     chain: 'ETH',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -947,7 +947,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await ethSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await ethSDK.erc721.send.burnSignedTransaction({
     chain: 'ETH',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -961,21 +961,21 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'ETH',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await ethSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'ETH',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
@@ -984,7 +984,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await ethSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await ethSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'ETH',
     tokenId: '123',
@@ -994,7 +994,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await ethSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'ETH',
       tokenId: [['123'], ['321']],
@@ -1004,7 +1004,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await ethSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'ETH',
       tokenId: [['123'], ['321']],
@@ -1014,7 +1014,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
@@ -1024,7 +1024,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await ethSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
@@ -1034,7 +1034,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await ethSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: ['123', '321'],
@@ -1044,7 +1044,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await ethSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: ['123', '321'],
@@ -1054,7 +1054,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await ethSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await ethSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'ETH',
       tokenId: '123',
       amount: '1',
@@ -1063,7 +1063,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentBurnMultiTokenTransaction = await ethSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await ethSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ETH',
     tokenId: '123',
     amount: '1',
@@ -1073,7 +1073,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await ethSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'ETH',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1083,7 +1083,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await ethSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await ethSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'ETH',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1094,7 +1094,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await ethSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await ethSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'ETH',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       enableFungibleTokens: true,
@@ -1108,7 +1108,7 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await ethSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await ethSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'ETH',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       enableFungibleTokens: true,

--- a/examples/eth-example/src/app/eth.tx.example.ts
+++ b/examples/eth-example/src/app/eth.tx.example.ts
@@ -167,75 +167,71 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await ethSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'ETH',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await ethSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'ETH',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await ethSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'ETH',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await ethSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'ETH',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await ethSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'ETH',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await ethSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'ETH',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await ethSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'ETH',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await ethSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'ETH',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await ethSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -269,8 +265,8 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedMintProvenanceSignedTransaction =
-    await ethSDK.erc721.prepare.mintProvenanceSignedTransaction({
+  const preparedMintProvenanceSignedTransaction = await ethSDK.erc721.prepare.mintProvenanceSignedTransaction(
+    {
       chain: 'ETH',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -282,22 +278,22 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintProvenanceSignedTransaction =
-    await ethSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'ETH',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await ethSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'ETH',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await ethSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -331,20 +327,18 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await ethSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'ETH',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await ethSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'ETH',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await ethSDK.erc721.send.transferSignedTransaction({
     chain: 'ETH',
@@ -412,29 +406,26 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'ETH',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await ethSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'ETH',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await ethSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'ETH',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await ethSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'ETH',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'ETH',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await ethSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'ETH',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await ethSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -455,35 +446,34 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await ethSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'ETH',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await ethSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'ETH',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await ethSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
       amount: '10',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await ethSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'ETH',
-      tokenId: '123',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await ethSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'ETH',
+    tokenId: '123',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await ethSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -505,15 +495,14 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'ETH',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const preparedBurnMultiTokenTransaction = await ethSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'ETH',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   const sentBurnMultiTokenTransaction = await ethSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ETH',
@@ -534,15 +523,14 @@ export async function ethTxWithSignatureIdExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await ethSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'ETH',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const sentMintBurnTokenBatchTransaction = await ethSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'ETH',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
@@ -715,75 +703,71 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await ethSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'ETH',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await ethSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'ETH',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await ethSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'ETH',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await ethSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'ETH',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await ethSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'ETH',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await ethSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'ETH',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await ethSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'ETH',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await ethSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'ETH',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await ethSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -817,8 +801,8 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedMintProvenanceSignedTransaction =
-    await ethSDK.erc721.prepare.mintProvenanceSignedTransaction({
+  const preparedMintProvenanceSignedTransaction = await ethSDK.erc721.prepare.mintProvenanceSignedTransaction(
+    {
       chain: 'ETH',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -830,22 +814,22 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintProvenanceSignedTransaction =
-    await ethSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'ETH',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await ethSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'ETH',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await ethSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -879,20 +863,18 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await ethSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'ETH',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await ethSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'ETH',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await ethSDK.erc721.send.transferSignedTransaction({
     chain: 'ETH',
@@ -960,29 +942,26 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'ETH',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await ethSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'ETH',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await ethSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'ETH',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await ethSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'ETH',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'ETH',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await ethSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'ETH',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await ethSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -1003,35 +982,34 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await ethSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'ETH',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await ethSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'ETH',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await ethSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'ETH',
       tokenId: '123',
       amount: '10',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await ethSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'ETH',
-      tokenId: '123',
-      amount: '10',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await ethSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'ETH',
+    tokenId: '123',
+    amount: '10',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await ethSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -1053,15 +1031,14 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await ethSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'ETH',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const preparedBurnMultiTokenTransaction = await ethSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'ETH',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   const sentBurnMultiTokenTransaction = await ethSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ETH',
@@ -1082,15 +1059,14 @@ export async function ethTxWithPrivateKeyExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await ethSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'ETH',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const sentMintBurnTokenBatchTransaction = await ethSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'ETH',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =

--- a/examples/kcs-example/src/app/kcs.tx.example.ts
+++ b/examples/kcs-example/src/app/kcs.tx.example.ts
@@ -5,7 +5,7 @@ const kcsSDK = TatumKcsSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function kcsTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction = await kcsSDK.transaction.native.prepare.transferSignedTransaction(
+  const preparedTransferNativeTransaction = await kcsSDK.transaction.prepare.transferSignedTransaction(
     {
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       amount: '10',
@@ -18,7 +18,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   )
 
-  const sentTransferNativeTransaction = await kcsSDK.transaction.native.send.transferSignedTransaction({
+  const sentTransferNativeTransaction = await kcsSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -30,7 +30,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await kcsSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await kcsSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -45,7 +45,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await kcsSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await kcsSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -60,7 +60,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await kcsSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await kcsSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -73,7 +73,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await kcsSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await kcsSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -86,7 +86,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await kcsSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await kcsSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -94,7 +94,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await kcsSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await kcsSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -102,14 +102,14 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await kcsSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await kcsSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await kcsSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await kcsSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -117,7 +117,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await kcsSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await kcsSDK.erc721.prepare.deploySignedTransaction({
     chain: 'KCS',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -129,7 +129,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await kcsSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await kcsSDK.erc721.send.deploySignedTransaction({
     chain: 'KCS',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -141,7 +141,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await kcsSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await kcsSDK.erc721.prepare.mintSignedTransaction({
     chain: 'KCS',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -155,7 +155,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await kcsSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await kcsSDK.erc721.send.mintSignedTransaction({
     chain: 'KCS',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -170,7 +170,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await kcsSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'KCS',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -189,7 +189,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await kcsSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await kcsSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'KCS',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -208,7 +208,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await kcsSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'KCS',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -224,7 +224,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await kcsSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'KCS',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -240,7 +240,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await kcsSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'KCS',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -256,7 +256,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await kcsSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'KCS',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -271,7 +271,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await kcsSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await kcsSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'KCS',
       tokenId: '453453',
@@ -286,7 +286,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await kcsSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await kcsSDK.erc721.send.transferSignedTransaction({
     chain: 'KCS',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -300,7 +300,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await kcsSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'KCS',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -314,7 +314,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await kcsSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await kcsSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'KCS',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -327,7 +327,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await kcsSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await kcsSDK.erc721.prepare.burnSignedTransaction({
     chain: 'KCS',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -339,7 +339,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await kcsSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await kcsSDK.erc721.send.burnSignedTransaction({
     chain: 'KCS',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -353,21 +353,21 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'KCS',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await kcsSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'KCS',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
@@ -376,7 +376,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await kcsSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await kcsSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'KCS',
     tokenId: '123',
@@ -386,7 +386,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'KCS',
       tokenId: [['123'], ['321']],
@@ -396,7 +396,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'KCS',
       tokenId: [['123'], ['321']],
@@ -406,7 +406,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
@@ -416,7 +416,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await kcsSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
@@ -426,7 +426,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: ['123', '321'],
@@ -436,7 +436,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: ['123', '321'],
@@ -446,7 +446,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'KCS',
       tokenId: '123',
       amount: '1',
@@ -455,7 +455,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentBurnMultiTokenTransaction = await kcsSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await kcsSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'KCS',
     tokenId: '123',
     amount: '1',
@@ -465,7 +465,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'KCS',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -475,7 +475,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'KCS',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -487,7 +487,7 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
 
 export async function kcsTxWithPrivateKeyExample(): Promise<void> {
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await kcsSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await kcsSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -502,7 +502,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await kcsSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await kcsSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -517,7 +517,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await kcsSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await kcsSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -530,7 +530,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await kcsSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await kcsSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -543,7 +543,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await kcsSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await kcsSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -551,7 +551,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await kcsSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await kcsSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -559,14 +559,14 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await kcsSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await kcsSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await kcsSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await kcsSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
@@ -574,7 +574,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
   })
 
   //ERC721(NFT)
-  const preparedDeployErc721Transaction = await kcsSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await kcsSDK.erc721.prepare.deploySignedTransaction({
     chain: 'KCS',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -586,7 +586,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await kcsSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await kcsSDK.erc721.send.deploySignedTransaction({
     chain: 'KCS',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -598,7 +598,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await kcsSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await kcsSDK.erc721.prepare.mintSignedTransaction({
     chain: 'KCS',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -612,7 +612,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await kcsSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await kcsSDK.erc721.send.mintSignedTransaction({
     chain: 'KCS',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -627,7 +627,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await kcsSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'KCS',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -646,7 +646,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await kcsSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await kcsSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'KCS',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -665,7 +665,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await kcsSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'KCS',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -681,7 +681,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await kcsSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'KCS',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -697,7 +697,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await kcsSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'KCS',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -713,7 +713,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await kcsSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await kcsSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'KCS',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -728,7 +728,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await kcsSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await kcsSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'KCS',
       tokenId: '453453',
@@ -743,7 +743,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await kcsSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await kcsSDK.erc721.send.transferSignedTransaction({
     chain: 'KCS',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -757,7 +757,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await kcsSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await kcsSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'KCS',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -771,7 +771,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await kcsSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await kcsSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'KCS',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -784,7 +784,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await kcsSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await kcsSDK.erc721.prepare.burnSignedTransaction({
     chain: 'KCS',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -796,7 +796,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await kcsSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await kcsSDK.erc721.send.burnSignedTransaction({
     chain: 'KCS',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -810,21 +810,21 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'KCS',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await kcsSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'KCS',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
@@ -833,7 +833,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await kcsSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await kcsSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     chain: 'KCS',
     tokenId: '123',
@@ -843,7 +843,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'KCS',
       tokenId: [['123'], ['321']],
@@ -853,7 +853,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
       chain: 'KCS',
       tokenId: [['123'], ['321']],
@@ -863,7 +863,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
@@ -873,7 +873,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await kcsSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
@@ -883,7 +883,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: ['123', '321'],
@@ -893,7 +893,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: ['123', '321'],
@@ -903,7 +903,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await kcsSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await kcsSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'KCS',
       tokenId: '123',
       amount: '1',
@@ -912,7 +912,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentBurnMultiTokenTransaction = await kcsSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await kcsSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'KCS',
     tokenId: '123',
     amount: '1',
@@ -922,7 +922,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'KCS',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -932,7 +932,7 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await kcsSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await kcsSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'KCS',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],

--- a/examples/kcs-example/src/app/kcs.tx.example.ts
+++ b/examples/kcs-example/src/app/kcs.tx.example.ts
@@ -5,18 +5,16 @@ const kcsSDK = TatumKcsSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function kcsTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction = await kcsSDK.transaction.prepare.transferSignedTransaction(
-    {
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 3252345722143,
-      fee: {
-        gasLimit: '53632',
-        gasPrice: '20',
-      },
+  const preparedTransferNativeTransaction = await kcsSDK.transaction.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 3252345722143,
+    fee: {
+      gasLimit: '53632',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferNativeTransaction = await kcsSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -169,75 +167,71 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await kcsSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'KCS',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await kcsSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'KCS',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await kcsSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'KCS',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await kcsSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'KCS',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await kcsSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'KCS',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await kcsSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'KCS',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await kcsSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'KCS',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await kcsSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'KCS',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await kcsSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -271,20 +265,18 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await kcsSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'KCS',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await kcsSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'KCS',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await kcsSDK.erc721.send.transferSignedTransaction({
     chain: 'KCS',
@@ -352,29 +344,26 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'KCS',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await kcsSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'KCS',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await kcsSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'KCS',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await kcsSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'KCS',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'KCS',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await kcsSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'KCS',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await kcsSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -395,35 +384,34 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await kcsSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'KCS',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await kcsSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'KCS',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await kcsSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
       amount: '10',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await kcsSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'KCS',
-      tokenId: '123',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await kcsSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'KCS',
+    tokenId: '123',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await kcsSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -445,15 +433,14 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'KCS',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const preparedBurnMultiTokenTransaction = await kcsSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'KCS',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   const sentBurnMultiTokenTransaction = await kcsSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'KCS',
@@ -474,15 +461,14 @@ export async function kcsTxWithSignatureIdExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await kcsSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'KCS',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const sentMintBurnTokenBatchTransaction = await kcsSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'KCS',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 }
 
 export async function kcsTxWithPrivateKeyExample(): Promise<void> {
@@ -626,75 +612,71 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await kcsSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'KCS',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await kcsSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'KCS',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await kcsSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'KCS',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await kcsSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'KCS',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await kcsSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'KCS',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await kcsSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'KCS',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await kcsSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'KCS',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await kcsSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'KCS',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await kcsSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -728,20 +710,18 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await kcsSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'KCS',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await kcsSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'KCS',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await kcsSDK.erc721.send.transferSignedTransaction({
     chain: 'KCS',
@@ -809,29 +789,26 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'KCS',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await kcsSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'KCS',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await kcsSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'KCS',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await kcsSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'KCS',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'KCS',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await kcsSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'KCS',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await kcsSDK.multiToken.send.mintMultiTokenTransaction({
     to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
@@ -852,35 +829,34 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await kcsSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
-      chain: 'KCS',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await kcsSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f', '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f'],
+    chain: 'KCS',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await kcsSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
       chain: 'KCS',
       tokenId: '123',
       amount: '10',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await kcsSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-      chain: 'KCS',
-      tokenId: '123',
-      amount: '10',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await kcsSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+    chain: 'KCS',
+    tokenId: '123',
+    amount: '10',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await kcsSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -902,15 +878,14 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await kcsSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'KCS',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const preparedBurnMultiTokenTransaction = await kcsSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'KCS',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 
   const sentBurnMultiTokenTransaction = await kcsSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'KCS',
@@ -931,13 +906,12 @@ export async function kcsTxWithPrivateKeyExample(): Promise<void> {
       account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await kcsSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'KCS',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
-    })
+  const sentMintBurnTokenBatchTransaction = await kcsSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'KCS',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x4b812a77b109A150C2Fc89eD133EaBC78bC9EC8f',
+  })
 }

--- a/examples/klaytn-example/src/app/klaytn.tx.example.ts
+++ b/examples/klaytn-example/src/app/klaytn.tx.example.ts
@@ -58,19 +58,18 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction =
-    await klaytnSDK.erc20.prepare.transferSignedTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      amount: '10',
-      contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      digits: 18,
-      nonce: 3252345722143,
-      fee: {
-        gasLimit: '53632',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferErc20Transaction = await klaytnSDK.erc20.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    amount: '10',
+    contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    digits: 18,
+    nonce: 3252345722143,
+    fee: {
+      gasLimit: '53632',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferErc20Transaction = await klaytnSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -168,75 +167,71 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await klaytnSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'KLAY',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await klaytnSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'KLAY',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await klaytnSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'KLAY',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await klaytnSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'KLAY',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await klaytnSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'KLAY',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await klaytnSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'KLAY',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await klaytnSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'KLAY',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await klaytnSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'KLAY',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await klaytnSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -285,20 +280,19 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const sentMintProvenanceSignedTransaction =
-    await klaytnSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'KLAY',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await klaytnSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'KLAY',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await klaytnSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -332,19 +326,18 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction =
-    await klaytnSDK.erc721.prepare.transferSignedTransaction({
-      chain: 'KLAY',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferSignedTransaction = await klaytnSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'KLAY',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferSignedTransaction = await klaytnSDK.erc721.send.transferSignedTransaction({
     chain: 'KLAY',
@@ -412,40 +405,35 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await klaytnSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'KLAY',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await klaytnSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'KLAY',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await klaytnSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'KLAY',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await klaytnSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'KLAY',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await klaytnSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await klaytnSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const sentMintMultiTokenTransaction = await klaytnSDK.multiToken.send.mintMultiTokenTransaction(
-    {
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    },
-  )
+  const sentMintMultiTokenTransaction = await klaytnSDK.multiToken.send.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedMintMultiTokenBatchTransaction =
     await klaytnSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
@@ -457,15 +445,14 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await klaytnSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      chain: 'KLAY',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await klaytnSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    chain: 'KLAY',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenTransaction =
     await klaytnSDK.multiToken.prepare.transferMultiTokenTransaction({
@@ -477,15 +464,14 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentTransferMultiTokenTransaction =
-    await klaytnSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await klaytnSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await klaytnSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -507,26 +493,23 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await klaytnSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const preparedBurnMultiTokenTransaction = await klaytnSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
-  const sentBurnMultiTokenTransaction = await klaytnSDK.multiToken.send.burnMultiTokenTransaction(
-    {
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    },
-  )
+  const sentBurnMultiTokenTransaction = await klaytnSDK.multiToken.send.burnMultiTokenTransaction({
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
   const preparedBurnMultiTokenBatchTransaction =
     await klaytnSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
@@ -538,15 +521,14 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await klaytnSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'KLAY',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const sentMintBurnTokenBatchTransaction = await klaytnSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'KLAY',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 }
 
 export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
@@ -581,19 +563,18 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction =
-    await klaytnSDK.erc20.prepare.transferSignedTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      amount: '10',
-      contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      digits: 18,
-      nonce: 3252345722143,
-      fee: {
-        gasLimit: '53632',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferErc20Transaction = await klaytnSDK.erc20.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    amount: '10',
+    contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    digits: 18,
+    nonce: 3252345722143,
+    fee: {
+      gasLimit: '53632',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferErc20Transaction = await klaytnSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -691,75 +672,71 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await klaytnSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'KLAY',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await klaytnSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'KLAY',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await klaytnSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'KLAY',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await klaytnSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'KLAY',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await klaytnSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'KLAY',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await klaytnSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'KLAY',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await klaytnSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'KLAY',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await klaytnSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'KLAY',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await klaytnSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -808,20 +785,19 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const sentMintProvenanceSignedTransaction =
-    await klaytnSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'KLAY',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await klaytnSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'KLAY',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await klaytnSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -855,19 +831,18 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction =
-    await klaytnSDK.erc721.prepare.transferSignedTransaction({
-      chain: 'KLAY',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferSignedTransaction = await klaytnSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'KLAY',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferSignedTransaction = await klaytnSDK.erc721.send.transferSignedTransaction({
     chain: 'KLAY',
@@ -935,40 +910,35 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await klaytnSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'KLAY',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await klaytnSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'KLAY',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await klaytnSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'KLAY',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await klaytnSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'KLAY',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await klaytnSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await klaytnSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const sentMintMultiTokenTransaction = await klaytnSDK.multiToken.send.mintMultiTokenTransaction(
-    {
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    },
-  )
+  const sentMintMultiTokenTransaction = await klaytnSDK.multiToken.send.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedMintMultiTokenBatchTransaction =
     await klaytnSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
@@ -980,15 +950,14 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await klaytnSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      chain: 'KLAY',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await klaytnSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    chain: 'KLAY',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenTransaction =
     await klaytnSDK.multiToken.prepare.transferMultiTokenTransaction({
@@ -1000,15 +969,14 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentTransferMultiTokenTransaction =
-    await klaytnSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '10',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await klaytnSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '10',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await klaytnSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -1030,26 +998,23 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await klaytnSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const preparedBurnMultiTokenTransaction = await klaytnSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
-  const sentBurnMultiTokenTransaction = await klaytnSDK.multiToken.send.burnMultiTokenTransaction(
-    {
-      chain: 'KLAY',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    },
-  )
+  const sentBurnMultiTokenTransaction = await klaytnSDK.multiToken.send.burnMultiTokenTransaction({
+    chain: 'KLAY',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
   const preparedBurnMultiTokenBatchTransaction =
     await klaytnSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
@@ -1061,13 +1026,12 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await klaytnSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'KLAY',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const sentMintBurnTokenBatchTransaction = await klaytnSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'KLAY',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 }

--- a/examples/klaytn-example/src/app/klaytn.tx.example.ts
+++ b/examples/klaytn-example/src/app/klaytn.tx.example.ts
@@ -5,7 +5,7 @@ const klaytnSDK = TatumKlaytnSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction = await klaytnSDK.transaction.native.prepare.transferSignedTransaction({
+  const preparedTransferNativeTransaction = await klaytnSDK.transaction.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -16,7 +16,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentTransferNativeTransaction = await klaytnSDK.transaction.native.send.transferSignedTransaction({
+  const sentTransferNativeTransaction = await klaytnSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -28,7 +28,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await klaytnSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await klaytnSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -43,7 +43,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await klaytnSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await klaytnSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -59,7 +59,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedTransferErc20Transaction =
-    await klaytnSDK.transaction.erc20.prepare.transferSignedTransaction({
+    await klaytnSDK.erc20.prepare.transferSignedTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       amount: '10',
       contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -72,7 +72,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const sentTransferErc20Transaction = await klaytnSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await klaytnSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -85,7 +85,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await klaytnSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await klaytnSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -93,7 +93,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await klaytnSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await klaytnSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -101,14 +101,14 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await klaytnSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await klaytnSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await klaytnSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await klaytnSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -116,7 +116,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await klaytnSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await klaytnSDK.erc721.prepare.deploySignedTransaction({
     chain: 'KLAY',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -128,7 +128,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await klaytnSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await klaytnSDK.erc721.send.deploySignedTransaction({
     chain: 'KLAY',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -140,7 +140,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await klaytnSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await klaytnSDK.erc721.prepare.mintSignedTransaction({
     chain: 'KLAY',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -154,7 +154,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await klaytnSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await klaytnSDK.erc721.send.mintSignedTransaction({
     chain: 'KLAY',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -169,7 +169,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -188,7 +188,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await klaytnSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -207,7 +207,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'KLAY',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -223,7 +223,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await klaytnSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'KLAY',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -239,7 +239,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'KLAY',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -255,7 +255,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await klaytnSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'KLAY',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -271,7 +271,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'KLAY',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -286,7 +286,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await klaytnSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'KLAY',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -301,7 +301,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -317,7 +317,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await klaytnSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -333,7 +333,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.transferSignedTransaction({
+    await klaytnSDK.erc721.prepare.transferSignedTransaction({
       chain: 'KLAY',
       tokenId: '453453',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -346,7 +346,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const sentTransferSignedTransaction = await klaytnSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await klaytnSDK.erc721.send.transferSignedTransaction({
     chain: 'KLAY',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -360,7 +360,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await klaytnSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'KLAY',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -374,7 +374,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await klaytnSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'KLAY',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -387,7 +387,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await klaytnSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await klaytnSDK.erc721.prepare.burnSignedTransaction({
     chain: 'KLAY',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -399,7 +399,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await klaytnSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await klaytnSDK.erc721.send.burnSignedTransaction({
     chain: 'KLAY',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -413,21 +413,21 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'KLAY',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await klaytnSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'KLAY',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: '123',
@@ -436,7 +436,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await klaytnSDK.transaction.multiToken.send.mintMultiTokenTransaction(
+  const sentMintMultiTokenTransaction = await klaytnSDK.multiToken.send.mintMultiTokenTransaction(
     {
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
@@ -448,7 +448,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   )
 
   const preparedMintMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'KLAY',
       tokenId: [['123'], ['321']],
@@ -458,7 +458,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'KLAY',
       tokenId: [['123'], ['321']],
@@ -468,7 +468,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: '123',
@@ -478,7 +478,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await klaytnSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: '123',
@@ -488,7 +488,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: ['123', '321'],
@@ -498,7 +498,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: ['123', '321'],
@@ -508,7 +508,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'KLAY',
       tokenId: '123',
       amount: '1',
@@ -517,7 +517,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
       account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     })
 
-  const sentBurnMultiTokenTransaction = await klaytnSDK.transaction.multiToken.send.burnMultiTokenTransaction(
+  const sentBurnMultiTokenTransaction = await klaytnSDK.multiToken.send.burnMultiTokenTransaction(
     {
       chain: 'KLAY',
       tokenId: '123',
@@ -529,7 +529,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
   )
 
   const preparedBurnMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'KLAY',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -539,7 +539,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'KLAY',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -551,7 +551,7 @@ export async function klaytnTxWithSignatureIdExample(): Promise<void> {
 
 export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await klaytnSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await klaytnSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -566,7 +566,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await klaytnSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await klaytnSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -582,7 +582,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedTransferErc20Transaction =
-    await klaytnSDK.transaction.erc20.prepare.transferSignedTransaction({
+    await klaytnSDK.erc20.prepare.transferSignedTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       amount: '10',
       contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -595,7 +595,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const sentTransferErc20Transaction = await klaytnSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await klaytnSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -608,7 +608,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await klaytnSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await klaytnSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -616,7 +616,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await klaytnSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await klaytnSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -624,14 +624,14 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await klaytnSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await klaytnSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await klaytnSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await klaytnSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
@@ -639,7 +639,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await klaytnSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await klaytnSDK.erc721.prepare.deploySignedTransaction({
     chain: 'KLAY',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -651,7 +651,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await klaytnSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await klaytnSDK.erc721.send.deploySignedTransaction({
     chain: 'KLAY',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -663,7 +663,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await klaytnSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await klaytnSDK.erc721.prepare.mintSignedTransaction({
     chain: 'KLAY',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -677,7 +677,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await klaytnSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await klaytnSDK.erc721.send.mintSignedTransaction({
     chain: 'KLAY',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -692,7 +692,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -711,7 +711,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await klaytnSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -730,7 +730,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'KLAY',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -746,7 +746,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await klaytnSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'KLAY',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -762,7 +762,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'KLAY',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -778,7 +778,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await klaytnSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'KLAY',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -794,7 +794,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'KLAY',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -809,7 +809,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await klaytnSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'KLAY',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -824,7 +824,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await klaytnSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -840,7 +840,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await klaytnSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'KLAY',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -856,7 +856,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.transferSignedTransaction({
+    await klaytnSDK.erc721.prepare.transferSignedTransaction({
       chain: 'KLAY',
       tokenId: '453453',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -869,7 +869,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const sentTransferSignedTransaction = await klaytnSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await klaytnSDK.erc721.send.transferSignedTransaction({
     chain: 'KLAY',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -883,7 +883,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await klaytnSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await klaytnSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'KLAY',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -897,7 +897,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await klaytnSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await klaytnSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'KLAY',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -910,7 +910,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await klaytnSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await klaytnSDK.erc721.prepare.burnSignedTransaction({
     chain: 'KLAY',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -922,7 +922,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await klaytnSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await klaytnSDK.erc721.send.burnSignedTransaction({
     chain: 'KLAY',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -936,21 +936,21 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'KLAY',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await klaytnSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'KLAY',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: '123',
@@ -959,7 +959,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await klaytnSDK.transaction.multiToken.send.mintMultiTokenTransaction(
+  const sentMintMultiTokenTransaction = await klaytnSDK.multiToken.send.mintMultiTokenTransaction(
     {
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
@@ -971,7 +971,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   )
 
   const preparedMintMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'KLAY',
       tokenId: [['123'], ['321']],
@@ -981,7 +981,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'KLAY',
       tokenId: [['123'], ['321']],
@@ -991,7 +991,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: '123',
@@ -1001,7 +1001,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await klaytnSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: '123',
@@ -1011,7 +1011,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: ['123', '321'],
@@ -1021,7 +1021,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'KLAY',
       tokenId: ['123', '321'],
@@ -1031,7 +1031,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await klaytnSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'KLAY',
       tokenId: '123',
       amount: '1',
@@ -1040,7 +1040,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
       account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     })
 
-  const sentBurnMultiTokenTransaction = await klaytnSDK.transaction.multiToken.send.burnMultiTokenTransaction(
+  const sentBurnMultiTokenTransaction = await klaytnSDK.multiToken.send.burnMultiTokenTransaction(
     {
       chain: 'KLAY',
       tokenId: '123',
@@ -1052,7 +1052,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
   )
 
   const preparedBurnMultiTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'KLAY',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1062,7 +1062,7 @@ export async function klaytnTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await klaytnSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await klaytnSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'KLAY',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],

--- a/examples/one-example/src/app/one.tx.example.ts
+++ b/examples/one-example/src/app/one.tx.example.ts
@@ -5,7 +5,7 @@ const oneSDK = TatumOneSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function oneTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction = await oneSDK.transaction.native.prepare.transferSignedTransaction(
+  const preparedTransferNativeTransaction = await oneSDK.transaction.prepare.transferSignedTransaction(
     {
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       amount: '10',
@@ -18,7 +18,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   )
 
-  const sentTransferNativeTransaction = await oneSDK.transaction.native.send.transferSignedTransaction({
+  const sentTransferNativeTransaction = await oneSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -30,7 +30,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await oneSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await oneSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -45,7 +45,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await oneSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await oneSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -60,7 +60,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await oneSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await oneSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -73,7 +73,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await oneSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await oneSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -86,7 +86,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await oneSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await oneSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -94,7 +94,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await oneSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await oneSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -102,14 +102,14 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await oneSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await oneSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await oneSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await oneSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -117,7 +117,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await oneSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await oneSDK.erc721.prepare.deploySignedTransaction({
     chain: 'ONE',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -129,7 +129,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await oneSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await oneSDK.erc721.send.deploySignedTransaction({
     chain: 'ONE',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -141,7 +141,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await oneSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await oneSDK.erc721.prepare.mintSignedTransaction({
     chain: 'ONE',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -155,7 +155,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await oneSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await oneSDK.erc721.send.mintSignedTransaction({
     chain: 'ONE',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -170,7 +170,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await oneSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -189,7 +189,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await oneSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -208,7 +208,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await oneSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'ONE',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -224,7 +224,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await oneSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'ONE',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -240,7 +240,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await oneSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'ONE',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -256,7 +256,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await oneSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'ONE',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -272,7 +272,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await oneSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'ONE',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -287,7 +287,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await oneSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'ONE',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -302,7 +302,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await oneSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -318,7 +318,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await oneSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -333,7 +333,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await oneSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await oneSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'ONE',
       tokenId: '453453',
@@ -348,7 +348,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await oneSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await oneSDK.erc721.send.transferSignedTransaction({
     chain: 'ONE',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -362,7 +362,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await oneSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'ONE',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -376,7 +376,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await oneSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await oneSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'ONE',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -389,7 +389,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await oneSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await oneSDK.erc721.prepare.burnSignedTransaction({
     chain: 'ONE',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -401,7 +401,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await oneSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await oneSDK.erc721.send.burnSignedTransaction({
     chain: 'ONE',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -415,21 +415,21 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'ONE',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await oneSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'ONE',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
@@ -438,7 +438,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await oneSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await oneSDK.multiToken.send.mintMultiTokenTransaction({
     to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
     chain: 'ONE',
     tokenId: '123',
@@ -448,7 +448,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await oneSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
       chain: 'ONE',
       tokenId: [['123'], ['321']],
@@ -458,7 +458,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await oneSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
       chain: 'ONE',
       tokenId: [['123'], ['321']],
@@ -468,7 +468,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
@@ -478,7 +478,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await oneSDK.multiToken.send.transferMultiTokenTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
@@ -488,7 +488,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await oneSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: ['123', '321'],
@@ -498,7 +498,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await oneSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: ['123', '321'],
@@ -508,7 +508,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'ONE',
       tokenId: '123',
       amount: '1',
@@ -517,7 +517,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
     })
 
-  const sentBurnMultiTokenTransaction = await oneSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await oneSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ONE',
     tokenId: '123',
     amount: '1',
@@ -527,7 +527,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await oneSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'ONE',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -537,7 +537,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await oneSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'ONE',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -548,7 +548,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await oneSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await oneSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'ONE',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -562,7 +562,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await oneSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await oneSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'ONE',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -578,7 +578,7 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
 
 export async function oneTxWithPrivateKeyExample(): Promise<void> {
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await oneSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await oneSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -593,7 +593,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await oneSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await oneSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -608,7 +608,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction = await oneSDK.transaction.erc20.prepare.transferSignedTransaction({
+  const preparedTransferErc20Transaction = await oneSDK.erc20.prepare.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -621,7 +621,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentTransferErc20Transaction = await oneSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await oneSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -634,7 +634,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await oneSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await oneSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -642,7 +642,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await oneSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await oneSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -650,14 +650,14 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await oneSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await oneSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await oneSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await oneSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
@@ -665,7 +665,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await oneSDK.transaction.erc721.prepare.deploySignedTransaction({
+  const preparedDeployErc721Transaction = await oneSDK.erc721.prepare.deploySignedTransaction({
     chain: 'ONE',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -677,7 +677,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc721Transaction = await oneSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await oneSDK.erc721.send.deploySignedTransaction({
     chain: 'ONE',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -689,7 +689,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await oneSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await oneSDK.erc721.prepare.mintSignedTransaction({
     chain: 'ONE',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -703,7 +703,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await oneSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await oneSDK.erc721.send.mintSignedTransaction({
     chain: 'ONE',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -718,7 +718,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await oneSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -737,7 +737,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await oneSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -756,7 +756,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await oneSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'ONE',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -772,7 +772,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await oneSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'ONE',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -788,7 +788,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await oneSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'ONE',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -804,7 +804,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await oneSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'ONE',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -820,7 +820,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await oneSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'ONE',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -835,7 +835,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await oneSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'ONE',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -850,7 +850,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await oneSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -866,7 +866,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await oneSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await oneSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'ONE',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -881,7 +881,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await oneSDK.transaction.erc721.prepare.transferSignedTransaction(
+  const preparedTransferSignedTransaction = await oneSDK.erc721.prepare.transferSignedTransaction(
     {
       chain: 'ONE',
       tokenId: '453453',
@@ -896,7 +896,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   )
 
-  const sentTransferSignedTransaction = await oneSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await oneSDK.erc721.send.transferSignedTransaction({
     chain: 'ONE',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -910,7 +910,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await oneSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await oneSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'ONE',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -924,7 +924,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await oneSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await oneSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'ONE',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -937,7 +937,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await oneSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await oneSDK.erc721.prepare.burnSignedTransaction({
     chain: 'ONE',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -949,7 +949,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await oneSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await oneSDK.erc721.send.burnSignedTransaction({
     chain: 'ONE',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -963,21 +963,21 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'ONE',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await oneSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'ONE',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
@@ -986,7 +986,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenTransaction = await oneSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+  const sentMintMultiTokenTransaction = await oneSDK.multiToken.send.mintMultiTokenTransaction({
     to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
     chain: 'ONE',
     tokenId: '123',
@@ -996,7 +996,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await oneSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
       chain: 'ONE',
       tokenId: [['123'], ['321']],
@@ -1006,7 +1006,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await oneSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
       chain: 'ONE',
       tokenId: [['123'], ['321']],
@@ -1016,7 +1016,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
@@ -1026,7 +1026,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await oneSDK.multiToken.send.transferMultiTokenTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
@@ -1036,7 +1036,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await oneSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: ['123', '321'],
@@ -1046,7 +1046,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await oneSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: ['123', '321'],
@@ -1056,7 +1056,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await oneSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await oneSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'ONE',
       tokenId: '123',
       amount: '1',
@@ -1065,7 +1065,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
     })
 
-  const sentBurnMultiTokenTransaction = await oneSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+  const sentBurnMultiTokenTransaction = await oneSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ONE',
     tokenId: '123',
     amount: '1',
@@ -1075,7 +1075,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await oneSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'ONE',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1085,7 +1085,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await oneSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await oneSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'ONE',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1096,7 +1096,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await oneSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await oneSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'ONE',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       enableFungibleTokens: true,
@@ -1110,7 +1110,7 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await oneSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await oneSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'ONE',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       enableFungibleTokens: true,

--- a/examples/one-example/src/app/one.tx.example.ts
+++ b/examples/one-example/src/app/one.tx.example.ts
@@ -5,18 +5,16 @@ const oneSDK = TatumOneSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function oneTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction = await oneSDK.transaction.prepare.transferSignedTransaction(
-    {
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 3252345722143,
-      fee: {
-        gasLimit: '53632',
-        gasPrice: '20',
-      },
+  const preparedTransferNativeTransaction = await oneSDK.transaction.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 3252345722143,
+    fee: {
+      gasLimit: '53632',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferNativeTransaction = await oneSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -169,75 +167,71 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await oneSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'ONE',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await oneSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'ONE',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await oneSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'ONE',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await oneSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'ONE',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await oneSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'ONE',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await oneSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'ONE',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await oneSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'ONE',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await oneSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'ONE',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await oneSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -271,8 +265,8 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedMintProvenanceSignedTransaction =
-    await oneSDK.erc721.prepare.mintProvenanceSignedTransaction({
+  const preparedMintProvenanceSignedTransaction = await oneSDK.erc721.prepare.mintProvenanceSignedTransaction(
+    {
       chain: 'ONE',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -284,22 +278,22 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintProvenanceSignedTransaction =
-    await oneSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'ONE',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await oneSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'ONE',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await oneSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -333,20 +327,18 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await oneSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'ONE',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await oneSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'ONE',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await oneSDK.erc721.send.transferSignedTransaction({
     chain: 'ONE',
@@ -414,29 +406,26 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'ONE',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await oneSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'ONE',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await oneSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'ONE',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await oneSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'ONE',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-      chain: 'ONE',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await oneSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+    chain: 'ONE',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await oneSDK.multiToken.send.mintMultiTokenTransaction({
     to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
@@ -457,35 +446,34 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await oneSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
-      chain: 'ONE',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await oneSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
+    chain: 'ONE',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await oneSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
       amount: '10',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await oneSDK.multiToken.send.transferMultiTokenTransaction({
-      to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-      chain: 'ONE',
-      tokenId: '123',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await oneSDK.multiToken.send.transferMultiTokenTransaction({
+    to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+    chain: 'ONE',
+    tokenId: '123',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await oneSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -507,15 +495,14 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'ONE',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-    })
+  const preparedBurnMultiTokenTransaction = await oneSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'ONE',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+  })
 
   const sentBurnMultiTokenTransaction = await oneSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ONE',
@@ -536,15 +523,14 @@ export async function oneTxWithSignatureIdExample(): Promise<void> {
       account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await oneSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'ONE',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-    })
+  const sentMintBurnTokenBatchTransaction = await oneSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'ONE',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
@@ -717,75 +703,71 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await oneSDK.erc721.prepare.mintMultipleSignedTransaction({
-      chain: 'ONE',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintMultipleSignedTransaction = await oneSDK.erc721.prepare.mintMultipleSignedTransaction({
+    chain: 'ONE',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await oneSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'ONE',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await oneSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'ONE',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await oneSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'ONE',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedMintCashbackSignedTransaction = await oneSDK.erc721.prepare.mintCashbackSignedTransaction({
+    chain: 'ONE',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await oneSDK.erc721.send.mintCashbackSignedTransaction({
-      chain: 'ONE',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintCashbackSignedTransaction = await oneSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'ONE',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await oneSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -819,8 +801,8 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedMintProvenanceSignedTransaction =
-    await oneSDK.erc721.prepare.mintProvenanceSignedTransaction({
+  const preparedMintProvenanceSignedTransaction = await oneSDK.erc721.prepare.mintProvenanceSignedTransaction(
+    {
       chain: 'ONE',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -832,22 +814,22 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintProvenanceSignedTransaction =
-    await oneSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'ONE',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await oneSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'ONE',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await oneSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -881,20 +863,18 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction = await oneSDK.erc721.prepare.transferSignedTransaction(
-    {
-      chain: 'ONE',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedTransferSignedTransaction = await oneSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'ONE',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentTransferSignedTransaction = await oneSDK.erc721.send.transferSignedTransaction({
     chain: 'ONE',
@@ -962,29 +942,26 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.deployMultiTokenTransaction({
-      chain: 'ONE',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const preparedDeployMultiTokenTransaction = await oneSDK.multiToken.prepare.deployMultiTokenTransaction({
+    chain: 'ONE',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const sentDeployMultiTokenTransaction =
-    await oneSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'ONE',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await oneSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'ONE',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-      chain: 'ONE',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await oneSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+    chain: 'ONE',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const sentMintMultiTokenTransaction = await oneSDK.multiToken.send.mintMultiTokenTransaction({
     to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
@@ -1005,35 +982,34 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await oneSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
-      chain: 'ONE',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await oneSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde', 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde'],
+    chain: 'ONE',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const preparedTransferMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.transferMultiTokenTransaction({
+  const preparedTransferMultiTokenTransaction = await oneSDK.multiToken.prepare.transferMultiTokenTransaction(
+    {
       to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
       chain: 'ONE',
       tokenId: '123',
       amount: '10',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+    },
+  )
 
-  const sentTransferMultiTokenTransaction =
-    await oneSDK.multiToken.send.transferMultiTokenTransaction({
-      to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-      chain: 'ONE',
-      tokenId: '123',
-      amount: '10',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await oneSDK.multiToken.send.transferMultiTokenTransaction({
+    to: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+    chain: 'ONE',
+    tokenId: '123',
+    amount: '10',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await oneSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -1055,15 +1031,14 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await oneSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'ONE',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-    })
+  const preparedBurnMultiTokenTransaction = await oneSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'ONE',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+  })
 
   const sentBurnMultiTokenTransaction = await oneSDK.multiToken.send.burnMultiTokenTransaction({
     chain: 'ONE',
@@ -1084,15 +1059,14 @@ export async function oneTxWithPrivateKeyExample(): Promise<void> {
       account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await oneSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'ONE',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
-    })
+  const sentMintBurnTokenBatchTransaction = await oneSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'ONE',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: 'one1yvph79875pj0pmgpxzmve87ks4sxer5u3jyfde',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =

--- a/examples/polygon-example/src/app/polygon.tx.example.ts
+++ b/examples/polygon-example/src/app/polygon.tx.example.ts
@@ -5,17 +5,16 @@ const polygonSDK = TatumPolygonSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function polygonTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
-  const preparedTransferNativeTransaction =
-    await polygonSDK.transaction.prepare.transferSignedTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 3252345722143,
-      fee: {
-        gasLimit: '53632',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferNativeTransaction = await polygonSDK.transaction.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 3252345722143,
+    fee: {
+      gasLimit: '53632',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferNativeTransaction = await polygonSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -59,19 +58,18 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction =
-    await polygonSDK.erc20.prepare.transferSignedTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      amount: '10',
-      contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      digits: 18,
-      nonce: 3252345722143,
-      fee: {
-        gasLimit: '53632',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferErc20Transaction = await polygonSDK.erc20.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    amount: '10',
+    contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    digits: 18,
+    nonce: 3252345722143,
+    fee: {
+      gasLimit: '53632',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferErc20Transaction = await polygonSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -117,19 +115,17 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await polygonSDK.erc721.prepare.deploySignedTransaction(
-    {
-      chain: 'MATIC',
-      name: 'MY_TOKEN',
-      symbol: '1oido3id3',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedDeployErc721Transaction = await polygonSDK.erc721.prepare.deploySignedTransaction({
+    chain: 'MATIC',
+    name: 'MY_TOKEN',
+    symbol: '1oido3id3',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentDeployErc721Transaction = await polygonSDK.erc721.send.deploySignedTransaction({
     chain: 'MATIC',
@@ -171,8 +167,8 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await polygonSDK.erc721.prepare.mintMultipleSignedTransaction({
+  const preparedMintMultipleSignedTransaction = await polygonSDK.erc721.prepare.mintMultipleSignedTransaction(
+    {
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -188,45 +184,29 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintMultipleSignedTransaction =
-    await polygonSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'MATIC',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await polygonSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'MATIC',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await polygonSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'MATIC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
-
-  const sentMintCashbackSignedTransaction =
-    await polygonSDK.erc721.send.mintCashbackSignedTransaction({
+  const preparedMintCashbackSignedTransaction = await polygonSDK.erc721.prepare.mintCashbackSignedTransaction(
+    {
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -239,7 +219,23 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
+
+  const sentMintCashbackSignedTransaction = await polygonSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'MATIC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await polygonSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -288,20 +284,19 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const sentMintProvenanceSignedTransaction =
-    await polygonSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'MATIC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await polygonSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'MATIC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await polygonSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -335,19 +330,18 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction =
-    await polygonSDK.erc721.prepare.transferSignedTransaction({
-      chain: 'MATIC',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferSignedTransaction = await polygonSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'MATIC',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferSignedTransaction = await polygonSDK.erc721.send.transferSignedTransaction({
     chain: 'MATIC',
@@ -415,39 +409,37 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await polygonSDK.multiToken.prepare.deployMultiTokenTransaction({
+  const preparedDeployMultiTokenTransaction = await polygonSDK.multiToken.prepare.deployMultiTokenTransaction(
+    {
       chain: 'MATIC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
-    })
+    },
+  )
 
-  const sentDeployMultiTokenTransaction =
-    await polygonSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'MATIC',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await polygonSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'MATIC',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await polygonSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await polygonSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const sentMintMultiTokenTransaction =
-    await polygonSDK.multiToken.send.mintMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1000',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenTransaction = await polygonSDK.multiToken.send.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1000',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedMintMultiTokenBatchTransaction =
     await polygonSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
@@ -459,15 +451,14 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await polygonSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      chain: 'MATIC',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await polygonSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    chain: 'MATIC',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenTransaction =
     await polygonSDK.multiToken.prepare.transferMultiTokenTransaction({
@@ -479,15 +470,14 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentTransferMultiTokenTransaction =
-    await polygonSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '10',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await polygonSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '10',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await polygonSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -509,25 +499,23 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await polygonSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const preparedBurnMultiTokenTransaction = await polygonSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
-  const sentBurnMultiTokenTransaction =
-    await polygonSDK.multiToken.send.burnMultiTokenTransaction({
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const sentBurnMultiTokenTransaction = await polygonSDK.multiToken.send.burnMultiTokenTransaction({
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
   const preparedBurnMultiTokenBatchTransaction =
     await polygonSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
@@ -539,15 +527,14 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await polygonSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'MATIC',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const sentMintBurnTokenBatchTransaction = await polygonSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'MATIC',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
@@ -611,19 +598,18 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedTransferErc20Transaction =
-    await polygonSDK.erc20.prepare.transferSignedTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      amount: '10',
-      contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      digits: 18,
-      nonce: 3252345722143,
-      fee: {
-        gasLimit: '53632',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferErc20Transaction = await polygonSDK.erc20.prepare.transferSignedTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    amount: '10',
+    contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    digits: 18,
+    nonce: 3252345722143,
+    fee: {
+      gasLimit: '53632',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferErc20Transaction = await polygonSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -669,19 +655,17 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await polygonSDK.erc721.prepare.deploySignedTransaction(
-    {
-      chain: 'MATIC',
-      name: 'MY_TOKEN',
-      symbol: '1oido3id3',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
+  const preparedDeployErc721Transaction = await polygonSDK.erc721.prepare.deploySignedTransaction({
+    chain: 'MATIC',
+    name: 'MY_TOKEN',
+    symbol: '1oido3id3',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
     },
-  )
+  })
 
   const sentDeployErc721Transaction = await polygonSDK.erc721.send.deploySignedTransaction({
     chain: 'MATIC',
@@ -723,8 +707,8 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await polygonSDK.erc721.prepare.mintMultipleSignedTransaction({
+  const preparedMintMultipleSignedTransaction = await polygonSDK.erc721.prepare.mintMultipleSignedTransaction(
+    {
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -740,45 +724,29 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
 
-  const sentMintMultipleSignedTransaction =
-    await polygonSDK.erc721.send.mintMultipleSignedTransaction({
-      chain: 'MATIC',
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      authorAddresses: [
-        ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-        ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
-      ],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintMultipleSignedTransaction = await polygonSDK.erc721.send.mintMultipleSignedTransaction({
+    chain: 'MATIC',
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    authorAddresses: [
+      ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+      ['0x687422eEA2cB73B5d3e242bA5456b782919AFc85'],
+    ],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await polygonSDK.erc721.prepare.mintCashbackSignedTransaction({
-      chain: 'MATIC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
-
-  const sentMintCashbackSignedTransaction =
-    await polygonSDK.erc721.send.mintCashbackSignedTransaction({
+  const preparedMintCashbackSignedTransaction = await polygonSDK.erc721.prepare.mintCashbackSignedTransaction(
+    {
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -791,7 +759,23 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
         gasLimit: '326452',
         gasPrice: '20',
       },
-    })
+    },
+  )
+
+  const sentMintCashbackSignedTransaction = await polygonSDK.erc721.send.mintCashbackSignedTransaction({
+    chain: 'MATIC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleCashbackSignedTransaction =
     await polygonSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
@@ -840,20 +824,19 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const sentMintProvenanceSignedTransaction =
-    await polygonSDK.erc721.send.mintProvenanceSignedTransaction({
-      chain: 'MATIC',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      tokenId: '5435345',
-      url: 'https://my_token_data.com',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const sentMintProvenanceSignedTransaction = await polygonSDK.erc721.send.mintProvenanceSignedTransaction({
+    chain: 'MATIC',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    tokenId: '5435345',
+    url: 'https://my_token_data.com',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const preparedMintMultipleProvenanceSignedTransaction =
     await polygonSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
@@ -887,19 +870,18 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedTransferSignedTransaction =
-    await polygonSDK.erc721.prepare.transferSignedTransaction({
-      chain: 'MATIC',
-      tokenId: '453453',
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
-      nonce: 46533715.43995557,
-      fee: {
-        gasLimit: '326452',
-        gasPrice: '20',
-      },
-    })
+  const preparedTransferSignedTransaction = await polygonSDK.erc721.prepare.transferSignedTransaction({
+    chain: 'MATIC',
+    tokenId: '453453',
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
+    nonce: 46533715.43995557,
+    fee: {
+      gasLimit: '326452',
+      gasPrice: '20',
+    },
+  })
 
   const sentTransferSignedTransaction = await polygonSDK.erc721.send.transferSignedTransaction({
     chain: 'MATIC',
@@ -967,39 +949,37 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC1155(MULTI TOKEN)
-  const preparedDeployMultiTokenTransaction =
-    await polygonSDK.multiToken.prepare.deployMultiTokenTransaction({
+  const preparedDeployMultiTokenTransaction = await polygonSDK.multiToken.prepare.deployMultiTokenTransaction(
+    {
       chain: 'MATIC',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
-    })
+    },
+  )
 
-  const sentDeployMultiTokenTransaction =
-    await polygonSDK.multiToken.send.deployMultiTokenTransaction({
-      chain: 'MATIC',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      uri: 'tatum',
-    })
+  const sentDeployMultiTokenTransaction = await polygonSDK.multiToken.send.deployMultiTokenTransaction({
+    chain: 'MATIC',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    uri: 'tatum',
+  })
 
-  const preparedMintMultiTokenTransaction =
-    await polygonSDK.multiToken.prepare.mintMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const preparedMintMultiTokenTransaction = await polygonSDK.multiToken.prepare.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
-  const sentMintMultiTokenTransaction =
-    await polygonSDK.multiToken.send.mintMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1000',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenTransaction = await polygonSDK.multiToken.send.mintMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1000',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedMintMultiTokenBatchTransaction =
     await polygonSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
@@ -1011,15 +991,14 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentMintMultiTokenBatchTransaction =
-    await polygonSDK.multiToken.send.mintMultiTokenBatchTransaction({
-      to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
-      chain: 'MATIC',
-      tokenId: [['123'], ['321']],
-      amounts: [['1000'], ['100']],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentMintMultiTokenBatchTransaction = await polygonSDK.multiToken.send.mintMultiTokenBatchTransaction({
+    to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
+    chain: 'MATIC',
+    tokenId: [['123'], ['321']],
+    amounts: [['1000'], ['100']],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenTransaction =
     await polygonSDK.multiToken.prepare.transferMultiTokenTransaction({
@@ -1031,15 +1010,14 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const sentTransferMultiTokenTransaction =
-    await polygonSDK.multiToken.send.transferMultiTokenTransaction({
-      to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '10',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-    })
+  const sentTransferMultiTokenTransaction = await polygonSDK.multiToken.send.transferMultiTokenTransaction({
+    to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '10',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+  })
 
   const preparedTransferMultiTokenBatchTransaction =
     await polygonSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
@@ -1061,25 +1039,23 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
     })
 
-  const preparedBurnMultiTokenTransaction =
-    await polygonSDK.multiToken.prepare.burnMultiTokenTransaction({
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const preparedBurnMultiTokenTransaction = await polygonSDK.multiToken.prepare.burnMultiTokenTransaction({
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
-  const sentBurnMultiTokenTransaction =
-    await polygonSDK.multiToken.send.burnMultiTokenTransaction({
-      chain: 'MATIC',
-      tokenId: '123',
-      amount: '1',
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const sentBurnMultiTokenTransaction = await polygonSDK.multiToken.send.burnMultiTokenTransaction({
+    chain: 'MATIC',
+    tokenId: '123',
+    amount: '1',
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
   const preparedBurnMultiTokenBatchTransaction =
     await polygonSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
@@ -1091,15 +1067,14 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     })
 
-  const sentMintBurnTokenBatchTransaction =
-    await polygonSDK.multiToken.send.burnMultiTokenBatchTransaction({
-      chain: 'MATIC',
-      tokenId: ['123', '321'],
-      amounts: ['1000', '100'],
-      fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
-      contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
-      account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
-    })
+  const sentMintBurnTokenBatchTransaction = await polygonSDK.multiToken.send.burnMultiTokenBatchTransaction({
+    chain: 'MATIC',
+    tokenId: ['123', '321'],
+    amounts: ['1000', '100'],
+    fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
+    contractAddress: '0x2c77a428b01e6403f237b7417a7091a3a5179f14',
+    account: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
+  })
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =

--- a/examples/polygon-example/src/app/polygon.tx.example.ts
+++ b/examples/polygon-example/src/app/polygon.tx.example.ts
@@ -6,7 +6,7 @@ const polygonSDK = TatumPolygonSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 export async function polygonTxWithSignatureIdExample(): Promise<void> {
   // NATIVE
   const preparedTransferNativeTransaction =
-    await polygonSDK.transaction.native.prepare.transferSignedTransaction({
+    await polygonSDK.transaction.prepare.transferSignedTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       amount: '10',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -17,7 +17,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const sentTransferNativeTransaction = await polygonSDK.transaction.native.send.transferSignedTransaction({
+  const sentTransferNativeTransaction = await polygonSDK.transaction.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -29,7 +29,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await polygonSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await polygonSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -44,7 +44,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await polygonSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await polygonSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -60,7 +60,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedTransferErc20Transaction =
-    await polygonSDK.transaction.erc20.prepare.transferSignedTransaction({
+    await polygonSDK.erc20.prepare.transferSignedTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       amount: '10',
       contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -73,7 +73,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const sentTransferErc20Transaction = await polygonSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await polygonSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -86,7 +86,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await polygonSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await polygonSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -94,7 +94,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await polygonSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await polygonSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -102,14 +102,14 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await polygonSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await polygonSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await polygonSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await polygonSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
@@ -117,7 +117,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await polygonSDK.transaction.erc721.prepare.deploySignedTransaction(
+  const preparedDeployErc721Transaction = await polygonSDK.erc721.prepare.deploySignedTransaction(
     {
       chain: 'MATIC',
       name: 'MY_TOKEN',
@@ -131,7 +131,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   )
 
-  const sentDeployErc721Transaction = await polygonSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await polygonSDK.erc721.send.deploySignedTransaction({
     chain: 'MATIC',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -143,7 +143,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await polygonSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await polygonSDK.erc721.prepare.mintSignedTransaction({
     chain: 'MATIC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -157,7 +157,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await polygonSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await polygonSDK.erc721.send.mintSignedTransaction({
     chain: 'MATIC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -172,7 +172,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await polygonSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -191,7 +191,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await polygonSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -210,7 +210,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await polygonSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -226,7 +226,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await polygonSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -242,7 +242,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await polygonSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'MATIC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -258,7 +258,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await polygonSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'MATIC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -274,7 +274,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await polygonSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'MATIC',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -289,7 +289,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await polygonSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -304,7 +304,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await polygonSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -320,7 +320,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await polygonSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -336,7 +336,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.transferSignedTransaction({
+    await polygonSDK.erc721.prepare.transferSignedTransaction({
       chain: 'MATIC',
       tokenId: '453453',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -349,7 +349,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const sentTransferSignedTransaction = await polygonSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await polygonSDK.erc721.send.transferSignedTransaction({
     chain: 'MATIC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -363,7 +363,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await polygonSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'MATIC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -377,7 +377,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await polygonSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await polygonSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'MATIC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -390,7 +390,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await polygonSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await polygonSDK.erc721.prepare.burnSignedTransaction({
     chain: 'MATIC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -402,7 +402,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await polygonSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await polygonSDK.erc721.send.burnSignedTransaction({
     chain: 'MATIC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -416,21 +416,21 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'MATIC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await polygonSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'MATIC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -440,7 +440,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+    await polygonSDK.multiToken.send.mintMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -450,7 +450,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'MATIC',
       tokenId: [['123'], ['321']],
@@ -460,7 +460,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'MATIC',
       tokenId: [['123'], ['321']],
@@ -470,7 +470,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -480,7 +480,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await polygonSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -490,7 +490,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: ['123', '321'],
@@ -500,7 +500,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: ['123', '321'],
@@ -510,7 +510,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'MATIC',
       tokenId: '123',
       amount: '1',
@@ -520,7 +520,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentBurnMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+    await polygonSDK.multiToken.send.burnMultiTokenTransaction({
       chain: 'MATIC',
       tokenId: '123',
       amount: '1',
@@ -530,7 +530,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'MATIC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -540,7 +540,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'MATIC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -551,7 +551,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await polygonSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await polygonSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'MATIC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -565,7 +565,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await polygonSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await polygonSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'MATIC',
       signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
       enableFungibleTokens: true,
@@ -581,7 +581,7 @@ export async function polygonTxWithSignatureIdExample(): Promise<void> {
 
 export async function polygonTxWithPrivateKeyExample(): Promise<void> {
   // ERC20(FUNGIBLE TOKEN)
-  const preparedDeployErc20Transaction = await polygonSDK.transaction.erc20.prepare.deploySignedTransaction({
+  const preparedDeployErc20Transaction = await polygonSDK.erc20.prepare.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -596,7 +596,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentDeployErc20Transaction = await polygonSDK.transaction.erc20.send.deploySignedTransaction({
+  const sentDeployErc20Transaction = await polygonSDK.erc20.send.deploySignedTransaction({
     symbol: 'ERC_SYMBOL',
     name: 'mytx',
     address: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -612,7 +612,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedTransferErc20Transaction =
-    await polygonSDK.transaction.erc20.prepare.transferSignedTransaction({
+    await polygonSDK.erc20.prepare.transferSignedTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       amount: '10',
       contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -625,7 +625,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const sentTransferErc20Transaction = await polygonSDK.transaction.erc20.send.transferSignedTransaction({
+  const sentTransferErc20Transaction = await polygonSDK.erc20.send.transferSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -638,7 +638,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintErc20Transaction = await polygonSDK.transaction.erc20.prepare.mintSignedTransaction({
+  const preparedMintErc20Transaction = await polygonSDK.erc20.prepare.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -646,7 +646,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const sentMintErc20Transaction = await polygonSDK.transaction.erc20.send.mintSignedTransaction({
+  const sentMintErc20Transaction = await polygonSDK.erc20.send.mintSignedTransaction({
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
@@ -654,14 +654,14 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     nonce: 3252345722143,
   })
 
-  const preparedBurnErc20Transaction = await polygonSDK.transaction.erc20.prepare.burnSignedTransaction({
+  const preparedBurnErc20Transaction = await polygonSDK.erc20.prepare.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
     nonce: 3252345722143,
   })
 
-  const sentBurnErc20Transaction = await polygonSDK.transaction.erc20.send.burnSignedTransaction({
+  const sentBurnErc20Transaction = await polygonSDK.erc20.send.burnSignedTransaction({
     amount: '10',
     contractAddress: '0x0b9808fce74030c87aae334a30f6c8f6c66b090d',
     fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
@@ -669,7 +669,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
   })
 
   // ERC721(NFT)
-  const preparedDeployErc721Transaction = await polygonSDK.transaction.erc721.prepare.deploySignedTransaction(
+  const preparedDeployErc721Transaction = await polygonSDK.erc721.prepare.deploySignedTransaction(
     {
       chain: 'MATIC',
       name: 'MY_TOKEN',
@@ -683,7 +683,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   )
 
-  const sentDeployErc721Transaction = await polygonSDK.transaction.erc721.send.deploySignedTransaction({
+  const sentDeployErc721Transaction = await polygonSDK.erc721.send.deploySignedTransaction({
     chain: 'MATIC',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -695,7 +695,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const preparedMintSignedTransaction = await polygonSDK.transaction.erc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await polygonSDK.erc721.prepare.mintSignedTransaction({
     chain: 'MATIC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -709,7 +709,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentMintSignedTransaction = await polygonSDK.transaction.erc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await polygonSDK.erc721.send.mintSignedTransaction({
     chain: 'MATIC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -724,7 +724,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintMultipleSignedTransaction({
+    await polygonSDK.erc721.prepare.mintMultipleSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -743,7 +743,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintMultipleSignedTransaction({
+    await polygonSDK.erc721.send.mintMultipleSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['345634563', '53545345'],
@@ -762,7 +762,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintCashbackSignedTransaction({
+    await polygonSDK.erc721.prepare.mintCashbackSignedTransaction({
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -778,7 +778,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintCashbackSignedTransaction({
+    await polygonSDK.erc721.send.mintCashbackSignedTransaction({
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       tokenId: '45343653',
@@ -794,7 +794,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintMultipleCashbackSignedTransaction({
+    await polygonSDK.erc721.prepare.mintMultipleCashbackSignedTransaction({
       chain: 'MATIC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -810,7 +810,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleCashbackSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintMultipleCashbackSignedTransaction({
+    await polygonSDK.erc721.send.mintMultipleCashbackSignedTransaction({
       chain: 'MATIC',
       tokenId: ['53564656', '536456456'],
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
@@ -826,7 +826,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintProvenanceSignedTransaction({
+    await polygonSDK.erc721.prepare.mintProvenanceSignedTransaction({
       chain: 'MATIC',
       tokenId: '5435345',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -841,7 +841,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintProvenanceSignedTransaction({
+    await polygonSDK.erc721.send.mintProvenanceSignedTransaction({
       chain: 'MATIC',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -856,7 +856,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultipleProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.mintMultipleProvenanceSignedTransaction({
+    await polygonSDK.erc721.prepare.mintMultipleProvenanceSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -872,7 +872,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleProvenanceSignedTransaction =
-    await polygonSDK.transaction.erc721.send.mintMultipleProvenanceSignedTransaction({
+    await polygonSDK.erc721.send.mintMultipleProvenanceSignedTransaction({
       chain: 'MATIC',
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       tokenId: ['53564656', '536456456'],
@@ -888,7 +888,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.transferSignedTransaction({
+    await polygonSDK.erc721.prepare.transferSignedTransaction({
       chain: 'MATIC',
       tokenId: '453453',
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -901,7 +901,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const sentTransferSignedTransaction = await polygonSDK.transaction.erc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await polygonSDK.erc721.send.transferSignedTransaction({
     chain: 'MATIC',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -915,7 +915,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await polygonSDK.transaction.erc721.prepare.updateCashbackForAuthorSignedTransaction({
+    await polygonSDK.erc721.prepare.updateCashbackForAuthorSignedTransaction({
       chain: 'MATIC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -929,7 +929,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await polygonSDK.transaction.erc721.send.updateCashbackForAuthorSignedTransaction({
+    await polygonSDK.erc721.send.updateCashbackForAuthorSignedTransaction({
       chain: 'MATIC',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -942,7 +942,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
       },
     })
 
-  const preparedBurnErc721Transaction = await polygonSDK.transaction.erc721.prepare.burnSignedTransaction({
+  const preparedBurnErc721Transaction = await polygonSDK.erc721.prepare.burnSignedTransaction({
     chain: 'MATIC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -954,7 +954,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     },
   })
 
-  const sentBurnErc721Transaction = await polygonSDK.transaction.erc721.send.burnSignedTransaction({
+  const sentBurnErc721Transaction = await polygonSDK.erc721.send.burnSignedTransaction({
     chain: 'MATIC',
     tokenId: '45343653',
     contractAddress: '0x687422eEA2cB73B5d3e242bA5456b782919AFc85',
@@ -968,21 +968,21 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
 
   // ERC1155(MULTI TOKEN)
   const preparedDeployMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.deployMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.deployMultiTokenTransaction({
       chain: 'MATIC',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const sentDeployMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.deployMultiTokenTransaction({
+    await polygonSDK.multiToken.send.deployMultiTokenTransaction({
       chain: 'MATIC',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       uri: 'tatum',
     })
 
   const preparedMintMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.mintMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.mintMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -992,7 +992,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.mintMultiTokenTransaction({
+    await polygonSDK.multiToken.send.mintMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -1002,7 +1002,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.prepare.mintMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.prepare.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'MATIC',
       tokenId: [['123'], ['321']],
@@ -1012,7 +1012,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.send.mintMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.send.mintMultiTokenBatchTransaction({
       to: ['0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9', '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9'],
       chain: 'MATIC',
       tokenId: [['123'], ['321']],
@@ -1022,7 +1022,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.transferMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -1032,7 +1032,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.transferMultiTokenTransaction({
+    await polygonSDK.multiToken.send.transferMultiTokenTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: '123',
@@ -1042,7 +1042,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.prepare.transferMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.prepare.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: ['123', '321'],
@@ -1052,7 +1052,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentTransferMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.send.transferMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.send.transferMultiTokenBatchTransaction({
       to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
       chain: 'MATIC',
       tokenId: ['123', '321'],
@@ -1062,7 +1062,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.prepare.burnMultiTokenTransaction({
+    await polygonSDK.multiToken.prepare.burnMultiTokenTransaction({
       chain: 'MATIC',
       tokenId: '123',
       amount: '1',
@@ -1072,7 +1072,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentBurnMultiTokenTransaction =
-    await polygonSDK.transaction.multiToken.send.burnMultiTokenTransaction({
+    await polygonSDK.multiToken.send.burnMultiTokenTransaction({
       chain: 'MATIC',
       tokenId: '123',
       amount: '1',
@@ -1082,7 +1082,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedBurnMultiTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.prepare.burnMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.prepare.burnMultiTokenBatchTransaction({
       chain: 'MATIC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1092,7 +1092,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintBurnTokenBatchTransaction =
-    await polygonSDK.transaction.multiToken.send.burnMultiTokenBatchTransaction({
+    await polygonSDK.multiToken.send.burnMultiTokenBatchTransaction({
       chain: 'MATIC',
       tokenId: ['123', '321'],
       amounts: ['1000', '100'],
@@ -1103,7 +1103,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
 
   // CUSTODIAL
   const preparedCustodialWalletSignedTransaction =
-    await polygonSDK.transaction.custodial.prepare.generateCustodialWalletSignedTransaction({
+    await polygonSDK.custodial.prepare.generateCustodialWalletSignedTransaction({
       chain: 'MATIC',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       enableFungibleTokens: true,
@@ -1117,7 +1117,7 @@ export async function polygonTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentCustodialWalletSignedTransaction =
-    await polygonSDK.transaction.custodial.send.generateCustodialWalletSignedTransaction({
+    await polygonSDK.custodial.send.generateCustodialWalletSignedTransaction({
       chain: 'MATIC',
       fromPrivateKey: '0x1612736ca819d2c5907a07d4e4dfb91dd5a8b3691079289afaee824ddcfdf495',
       enableFungibleTokens: true,

--- a/examples/tron-example/src/app/tron.tx.example.ts
+++ b/examples/tron-example/src/app/tron.tx.example.ts
@@ -4,21 +4,21 @@ import { REPLACE_ME_WITH_TATUM_API_KEY } from '@tatumio/shared-testing-common'
 const tronSDK = TatumTronSDK({ apiKey: REPLACE_ME_WITH_TATUM_API_KEY })
 
 export async function tronTxWithPrivateKeyExample(): Promise<void> {
-  const preparedDeployTrc10Transaction = await tronSDK.transaction.trc10.prepare.signedTransaction({
+  const preparedDeployTrc10Transaction = await tronSDK.trc10.prepare.signedTransaction({
     amount: '10',
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     tokenId: '1000538',
   })
 
-  const sentDeployTrc10Transaction = await tronSDK.transaction.trc10.send.signedTransaction({
+  const sentDeployTrc10Transaction = await tronSDK.trc10.send.signedTransaction({
     amount: '10',
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     tokenId: '1000538',
   })
 
-  const preparedCreateTrc10Transaction = await tronSDK.transaction.trc10.prepare.createSignedTransaction({
+  const preparedCreateTrc10Transaction = await tronSDK.trc10.prepare.createSignedTransaction({
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     abbreviation: 'TTM',
     recipient: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -29,7 +29,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     decimals: 18,
   })
 
-  const sentCreateTrc10Transaction = await tronSDK.transaction.trc10.send.createSignedTransaction({
+  const sentCreateTrc10Transaction = await tronSDK.trc10.send.createSignedTransaction({
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     abbreviation: 'TTM',
     recipient: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -40,17 +40,17 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     decimals: 18,
   })
 
-  const accountAddress = await tronSDK.transaction.trc20.getAccountTrc20Address(
+  const accountAddress = await tronSDK.trc20.getAccountTrc20Address(
     'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
   )
 
-  const contractDecimals = await tronSDK.transaction.trc20.getTrc20ContractDecimals(
+  const contractDecimals = await tronSDK.trc20.getTrc20ContractDecimals(
     'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
   )
 
-  const preparedTrc20Transaction = await tronSDK.transaction.trc20.prepare.signedTransaction({
+  const preparedTrc20Transaction = await tronSDK.trc20.prepare.signedTransaction({
     amount: '10',
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -58,7 +58,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     feeLimit: 100,
   })
 
-  const sentTrc20Transaction = await tronSDK.transaction.trc20.send.signedTransaction({
+  const sentTrc20Transaction = await tronSDK.trc20.send.signedTransaction({
     amount: '10',
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -66,7 +66,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     feeLimit: 100,
   })
 
-  const preparedTrc20CreateTransaction = await tronSDK.transaction.trc20.prepare.createSignedTransaction({
+  const preparedTrc20CreateTransaction = await tronSDK.trc20.prepare.createSignedTransaction({
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     recipient: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     totalSupply: 100,
@@ -75,7 +75,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     symbol: 'TTM',
   })
 
-  const sentTrc20CreateTransaction = await tronSDK.transaction.trc20.send.createSignedTransaction({
+  const sentTrc20CreateTransaction = await tronSDK.trc20.send.createSignedTransaction({
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     recipient: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     totalSupply: 100,
@@ -84,7 +84,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     symbol: 'TTM',
   })
 
-  const preparedDeployTrc721Transaction = await tronSDK.transaction.trc721.prepare.deploySignedTransaction({
+  const preparedDeployTrc721Transaction = await tronSDK.trc721.prepare.deploySignedTransaction({
     chain: 'TRON',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -93,7 +93,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
   })
 
-  const sentDeployTrc721Transaction = await tronSDK.transaction.trc721.send.deploySignedTransaction({
+  const sentDeployTrc721Transaction = await tronSDK.trc721.send.deploySignedTransaction({
     chain: 'TRON',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -102,7 +102,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
   })
 
-  const preparedMintSignedTransaction = await tronSDK.transaction.trc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await tronSDK.trc721.prepare.mintSignedTransaction({
     chain: 'TRON',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -113,7 +113,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
   })
 
-  const sentMintSignedTransaction = await tronSDK.transaction.trc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await tronSDK.trc721.send.mintSignedTransaction({
     chain: 'TRON',
     tokenId: '453453',
     to: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
@@ -125,7 +125,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.mintMultipleSignedTransaction({
+    await tronSDK.trc721.prepare.mintMultipleSignedTransaction({
       chain: 'TRON',
       to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
       tokenId: ['345634563', '53545345'],
@@ -137,7 +137,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await tronSDK.transaction.trc721.send.mintMultipleSignedTransaction({
+    await tronSDK.trc721.send.mintMultipleSignedTransaction({
       chain: 'TRON',
       to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
       tokenId: ['345634563', '53545345'],
@@ -149,7 +149,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.mintCashbackSignedTransaction({
+    await tronSDK.trc721.prepare.mintCashbackSignedTransaction({
       chain: 'TRON',
       to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
       tokenId: '45343653',
@@ -162,7 +162,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await tronSDK.transaction.trc721.send.mintCashbackSignedTransaction({
+    await tronSDK.trc721.send.mintCashbackSignedTransaction({
       chain: 'TRON',
       to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
       tokenId: '45343653',
@@ -175,7 +175,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.transferSignedTransaction({
+    await tronSDK.trc721.prepare.transferSignedTransaction({
       chain: 'TRON',
       tokenId: '453453',
       to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -185,7 +185,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
       fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     })
 
-  const sentTransferSignedTransaction = await tronSDK.transaction.trc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await tronSDK.trc721.send.transferSignedTransaction({
     chain: 'TRON',
     tokenId: '453453',
     to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -196,7 +196,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.updateCashbackValueForAuthorSignedTransaction({
+    await tronSDK.trc721.prepare.updateCashbackValueForAuthorSignedTransaction({
       chain: 'TRON',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -207,7 +207,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await tronSDK.transaction.trc721.send.updateCashbackValueForAuthorSignedTransaction({
+    await tronSDK.trc721.send.updateCashbackValueForAuthorSignedTransaction({
       chain: 'TRON',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -217,7 +217,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
       fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
     })
 
-  const preparedBurnTrc721Transaction = await tronSDK.transaction.trc721.prepare.burnSignedTransaction({
+  const preparedBurnTrc721Transaction = await tronSDK.trc721.prepare.burnSignedTransaction({
     chain: 'TRON',
     tokenId: '45343653',
     contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
@@ -226,7 +226,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     feeLimit: 100,
   })
 
-  const sentBurnTrc721Transaction = await tronSDK.transaction.trc721.send.burnSignedTransaction({
+  const sentBurnTrc721Transaction = await tronSDK.trc721.send.burnSignedTransaction({
     chain: 'TRON',
     tokenId: '45343653',
     contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
@@ -237,7 +237,7 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
 }
 
 export async function tronTxWithSignatureIdExample(): Promise<void> {
-  const preparedDeployTrc10Transaction = await tronSDK.transaction.trc10.prepare.signedTransaction({
+  const preparedDeployTrc10Transaction = await tronSDK.trc10.prepare.signedTransaction({
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -246,7 +246,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     index: 1,
   })
 
-  const sentDeployTrc10Transaction = await tronSDK.transaction.trc10.send.signedTransaction({
+  const sentDeployTrc10Transaction = await tronSDK.trc10.send.signedTransaction({
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -255,7 +255,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     tokenId: '1000538',
   })
 
-  const preparedCreateTrc10Transaction = await tronSDK.transaction.trc10.prepare.createSignedTransaction({
+  const preparedCreateTrc10Transaction = await tronSDK.trc10.prepare.createSignedTransaction({
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     index: 1,
@@ -268,7 +268,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     decimals: 18,
   })
 
-  const sentCreateTrc10Transaction = await tronSDK.transaction.trc10.send.createSignedTransaction({
+  const sentCreateTrc10Transaction = await tronSDK.trc10.send.createSignedTransaction({
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     index: 1,
@@ -281,7 +281,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     decimals: 18,
   })
 
-  const preparedTrc20Transaction = await tronSDK.transaction.trc20.prepare.signedTransaction({
+  const preparedTrc20Transaction = await tronSDK.trc20.prepare.signedTransaction({
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -291,7 +291,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     feeLimit: 100,
   })
 
-  const sentTrc20Transaction = await tronSDK.transaction.trc20.send.signedTransaction({
+  const sentTrc20Transaction = await tronSDK.trc20.send.signedTransaction({
     amount: '10',
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -301,7 +301,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     feeLimit: 100,
   })
 
-  const preparedTrc20CreateTransaction = await tronSDK.transaction.trc20.prepare.createSignedTransaction({
+  const preparedTrc20CreateTransaction = await tronSDK.trc20.prepare.createSignedTransaction({
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     index: 1,
@@ -312,7 +312,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     symbol: 'TTM',
   })
 
-  const sentTrc20CreateTransaction = await tronSDK.transaction.trc20.send.createSignedTransaction({
+  const sentTrc20CreateTransaction = await tronSDK.trc20.send.createSignedTransaction({
     signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
     from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
     index: 1,
@@ -323,7 +323,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     symbol: 'TTM',
   })
 
-  const preparedDeployTrc721Transaction = await tronSDK.transaction.trc721.prepare.deploySignedTransaction({
+  const preparedDeployTrc721Transaction = await tronSDK.trc721.prepare.deploySignedTransaction({
     chain: 'TRON',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -334,7 +334,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     index: 1,
   })
 
-  const sentDeployTrc721Transaction = await tronSDK.transaction.trc721.send.deploySignedTransaction({
+  const sentDeployTrc721Transaction = await tronSDK.trc721.send.deploySignedTransaction({
     chain: 'TRON',
     name: 'MY_TOKEN',
     symbol: '1oido3id3',
@@ -345,7 +345,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     index: 1,
   })
 
-  const preparedMintSignedTransaction = await tronSDK.transaction.trc721.prepare.mintSignedTransaction({
+  const preparedMintSignedTransaction = await tronSDK.trc721.prepare.mintSignedTransaction({
     chain: 'TRON',
     tokenId: '453453',
     to: '0x811DfbFF13ADFBC3Cf653dCc373C03616D3471c9',
@@ -358,7 +358,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     index: 1,
   })
 
-  const sentMintSignedTransaction = await tronSDK.transaction.trc721.send.mintSignedTransaction({
+  const sentMintSignedTransaction = await tronSDK.trc721.send.mintSignedTransaction({
     chain: 'TRON',
     tokenId: '453453',
     to: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
@@ -372,7 +372,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedMintMultipleSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.mintMultipleSignedTransaction({
+    await tronSDK.trc721.prepare.mintMultipleSignedTransaction({
       chain: 'TRON',
       to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
       tokenId: ['345634563', '53545345'],
@@ -386,7 +386,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintMultipleSignedTransaction =
-    await tronSDK.transaction.trc721.send.mintMultipleSignedTransaction({
+    await tronSDK.trc721.send.mintMultipleSignedTransaction({
       chain: 'TRON',
       to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
       tokenId: ['345634563', '53545345'],
@@ -400,7 +400,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedMintCashbackSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.mintCashbackSignedTransaction({
+    await tronSDK.trc721.prepare.mintCashbackSignedTransaction({
       chain: 'TRON',
       to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
       tokenId: '45343653',
@@ -415,7 +415,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentMintCashbackSignedTransaction =
-    await tronSDK.transaction.trc721.send.mintCashbackSignedTransaction({
+    await tronSDK.trc721.send.mintCashbackSignedTransaction({
       chain: 'TRON',
       to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
       tokenId: '45343653',
@@ -430,7 +430,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     })
 
   const preparedTransferSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.transferSignedTransaction({
+    await tronSDK.trc721.prepare.transferSignedTransaction({
       chain: 'TRON',
       tokenId: '453453',
       to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -442,7 +442,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
       index: 1,
     })
 
-  const sentTransferSignedTransaction = await tronSDK.transaction.trc721.send.transferSignedTransaction({
+  const sentTransferSignedTransaction = await tronSDK.trc721.send.transferSignedTransaction({
     chain: 'TRON',
     tokenId: '453453',
     to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
@@ -455,7 +455,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
   })
 
   const preparedUpdateCashbackForAuthorSignedTransaction =
-    await tronSDK.transaction.trc721.prepare.updateCashbackValueForAuthorSignedTransaction({
+    await tronSDK.trc721.prepare.updateCashbackValueForAuthorSignedTransaction({
       chain: 'TRON',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -468,7 +468,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     })
 
   const sentUpdateCashbackForAuthorSignedTransaction =
-    await tronSDK.transaction.trc721.send.updateCashbackValueForAuthorSignedTransaction({
+    await tronSDK.trc721.send.updateCashbackValueForAuthorSignedTransaction({
       chain: 'TRON',
       tokenId: '453453',
       cashbackValue: '0.8',
@@ -480,7 +480,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
       index: 1,
     })
 
-  const preparedBurnTrc721Transaction = await tronSDK.transaction.trc721.prepare.burnSignedTransaction({
+  const preparedBurnTrc721Transaction = await tronSDK.trc721.prepare.burnSignedTransaction({
     chain: 'TRON',
     tokenId: '45343653',
     contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
@@ -491,7 +491,7 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     feeLimit: 100,
   })
 
-  const sentBurnTrc721Transaction = await tronSDK.transaction.trc721.send.burnSignedTransaction({
+  const sentBurnTrc721Transaction = await tronSDK.trc721.send.burnSignedTransaction({
     chain: 'TRON',
     tokenId: '45343653',
     contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',

--- a/examples/tron-example/src/app/tron.tx.example.ts
+++ b/examples/tron-example/src/app/tron.tx.example.ts
@@ -124,66 +124,61 @@ export async function tronTxWithPrivateKeyExample(): Promise<void> {
     fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await tronSDK.trc721.prepare.mintMultipleSignedTransaction({
-      chain: 'TRON',
-      to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
-    })
+  const preparedMintMultipleSignedTransaction = await tronSDK.trc721.prepare.mintMultipleSignedTransaction({
+    chain: 'TRON',
+    to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await tronSDK.trc721.send.mintMultipleSignedTransaction({
-      chain: 'TRON',
-      to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
-    })
+  const sentMintMultipleSignedTransaction = await tronSDK.trc721.send.mintMultipleSignedTransaction({
+    chain: 'TRON',
+    to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await tronSDK.trc721.prepare.mintCashbackSignedTransaction({
-      chain: 'TRON',
-      to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
-    })
+  const preparedMintCashbackSignedTransaction = await tronSDK.trc721.prepare.mintCashbackSignedTransaction({
+    chain: 'TRON',
+    to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await tronSDK.trc721.send.mintCashbackSignedTransaction({
-      chain: 'TRON',
-      to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
-    })
+  const sentMintCashbackSignedTransaction = await tronSDK.trc721.send.mintCashbackSignedTransaction({
+    chain: 'TRON',
+    to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
+  })
 
-  const preparedTransferSignedTransaction =
-    await tronSDK.trc721.prepare.transferSignedTransaction({
-      chain: 'TRON',
-      tokenId: '453453',
-      to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
-    })
+  const preparedTransferSignedTransaction = await tronSDK.trc721.prepare.transferSignedTransaction({
+    chain: 'TRON',
+    tokenId: '453453',
+    to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    fromPrivateKey: '842E09EB40D8175979EFB0071B28163E11AED0F14BDD84090A4CEFB936EF5701',
+  })
 
   const sentTransferSignedTransaction = await tronSDK.trc721.send.transferSignedTransaction({
     chain: 'TRON',
@@ -371,76 +366,71 @@ export async function tronTxWithSignatureIdExample(): Promise<void> {
     index: 1,
   })
 
-  const preparedMintMultipleSignedTransaction =
-    await tronSDK.trc721.prepare.mintMultipleSignedTransaction({
-      chain: 'TRON',
-      to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      index: 1,
-    })
+  const preparedMintMultipleSignedTransaction = await tronSDK.trc721.prepare.mintMultipleSignedTransaction({
+    chain: 'TRON',
+    to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    index: 1,
+  })
 
-  const sentMintMultipleSignedTransaction =
-    await tronSDK.trc721.send.mintMultipleSignedTransaction({
-      chain: 'TRON',
-      to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
-      tokenId: ['345634563', '53545345'],
-      url: ['https://my_token_data.com', 'https://my_token_data2.com'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      index: 1,
-    })
+  const sentMintMultipleSignedTransaction = await tronSDK.trc721.send.mintMultipleSignedTransaction({
+    chain: 'TRON',
+    to: ['TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh'],
+    tokenId: ['345634563', '53545345'],
+    url: ['https://my_token_data.com', 'https://my_token_data2.com'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    index: 1,
+  })
 
-  const preparedMintCashbackSignedTransaction =
-    await tronSDK.trc721.prepare.mintCashbackSignedTransaction({
-      chain: 'TRON',
-      to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      index: 1,
-    })
+  const preparedMintCashbackSignedTransaction = await tronSDK.trc721.prepare.mintCashbackSignedTransaction({
+    chain: 'TRON',
+    to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    index: 1,
+  })
 
-  const sentMintCashbackSignedTransaction =
-    await tronSDK.trc721.send.mintCashbackSignedTransaction({
-      chain: 'TRON',
-      to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      tokenId: '45343653',
-      url: 'https://my_token_data.com',
-      cashbackValues: ['0.5', '0.5'],
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      index: 1,
-    })
+  const sentMintCashbackSignedTransaction = await tronSDK.trc721.send.mintCashbackSignedTransaction({
+    chain: 'TRON',
+    to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    tokenId: '45343653',
+    url: 'https://my_token_data.com',
+    cashbackValues: ['0.5', '0.5'],
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    index: 1,
+  })
 
-  const preparedTransferSignedTransaction =
-    await tronSDK.trc721.prepare.transferSignedTransaction({
-      chain: 'TRON',
-      tokenId: '453453',
-      to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
-      feeLimit: 100,
-      account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
-      from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
-      index: 1,
-    })
+  const preparedTransferSignedTransaction = await tronSDK.trc721.prepare.transferSignedTransaction({
+    chain: 'TRON',
+    tokenId: '453453',
+    to: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    contractAddress: 'TCrmdJmvDUPy8qSTgoVStF51yWm6VUh5yQ',
+    feeLimit: 100,
+    account: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    signatureId: 'cac88687-33ed-4ca1-b1fc-b02986a90975',
+    from: 'TYMwiDu22V6XG3yk6W9cTVBz48okKLRczh',
+    index: 1,
+  })
 
   const sentTransferSignedTransaction = await tronSDK.trc721.send.transferSignedTransaction({
     chain: 'TRON',

--- a/packages/blockchain/algo/src/lib/algo.sdk.ts
+++ b/packages/blockchain/algo/src/lib/algo.sdk.ts
@@ -11,6 +11,7 @@ const blockchain = Blockchain.ALGO
 
 export const TatumAlgoSDK = (args: SDKArguments) => {
   const web = algoWeb()
+  const txService = algoTx({ algoWeb: web })
 
   return {
     ...abstractBlockchainSdk({
@@ -20,9 +21,9 @@ export const TatumAlgoSDK = (args: SDKArguments) => {
     algoWeb: web,
     record: algoRecord(),
     wallet: algoWallet(),
-    transaction: algoTx({
-      algoWeb: web,
-    }),
+    transaction: txService.native,
+    erc20: txService.erc20,
+    erc721: txService.erc721,
     blockchain: {
       broadcast: BlockchainAlgorandAlgoService.algoandBroadcast,
       getBlock: BlockchainAlgorandAlgoService.algorandGetBlock,

--- a/packages/blockchain/algo/src/lib/services/algo.tx.ts
+++ b/packages/blockchain/algo/src/lib/services/algo.tx.ts
@@ -310,191 +310,210 @@ const prepareBurnFTSignedTransaction = async (
 
 export const algoTx = (args: { algoWeb: AlgoWeb }) => {
   return {
-    prepare: {
-      /**
-       * Algorand transaction signing
-       * @param testnet if the algorand node is testnet or not
-       * @param body content of the transaction to broadcast
-       * @param provider url of the algorand server endpoint for purestake.io restapi
-       * @returns transaction data to be broadcast to blockchain
-       */
-      signedTransaction: async (body: TransferAlgo | TransferAlgoKMS, testnet = false, provider?: string) =>
-        prepareSignedTransaction(body, testnet, args.algoWeb, provider),
-      /**
-       * Sign Algorand create NFT transaction with private key locally. Nothing is broadcast to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction data to be broadcast to blockchain
-       */
-      createNFTSignedTransaction: async (
-        body: DeployNft | DeployNftKMS,
-        testnet = false,
-        provider?: string,
-      ) => prepareCreateNFTSignedTransaction(body, testnet, args.algoWeb, provider),
-      /**
-       * Sign Algorand transfer NFT transaction with private key locally. Nothing is broadcast to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      transferNFTSignedTransaction: async (
-        body: TransferNft | TransferNftKMS,
-        testnet = false,
-        provider?: string,
-      ) => prepareTransferNFTSignedTransaction(body, testnet, args.algoWeb, provider),
-      /**
-       * Sign Algorand burn NFT transaction with private key locally. Nothing is broadcast to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      burnNFTSignedTransaction: async (body: BurnNft | BurnNftKMS, testnet = false, provider?: string) =>
-        prepareBurnNFTSignedTransaction(body, testnet, args.algoWeb, provider),
-      /**
-       * Sign Algorand create FT transaction with private key locally. Nothing is broadcast to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connnect to. If not set, default public server will be used.
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      createFTSignedTransaction: async (
-        body: DeployErc20 | DeployErc20KMS,
-        testnet = false,
-        provider?: string,
-      ) => prepareCreateFTSignedTransaction(body, testnet, args.algoWeb, provider),
-      /**
-       * Sign Algorand transfer FT transaction with private kwy locally. Nothing is broadcast to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param tx content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      transferFTSignedTransaction: async (
-        body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
-        testnet = false,
-        provider?: string,
-      ) => prepareTransferFTSignedTransaction(body, testnet, args.algoWeb, provider),
-      /**
-       * Sign ALgorand burn FT transaction with private key locally. Nothing is broadcast to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      burnFTSignedTransaction: async (
-        body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
-        testnet = false,
-        provider?: string,
-      ) => prepareBurnFTSignedTransaction(body, testnet, args.algoWeb, provider),
+    erc20: {
+      prepare: {
+        /**
+         * Sign Algorand create FT transaction with private key locally. Nothing is broadcast to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connnect to. If not set, default public server will be used.
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        createFTSignedTransaction: async (
+          body: DeployErc20 | DeployErc20KMS,
+          testnet = false,
+          provider?: string,
+        ) => prepareCreateFTSignedTransaction(body, testnet, args.algoWeb, provider),
+        /**
+         * Sign Algorand transfer FT transaction with private kwy locally. Nothing is broadcast to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param tx content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        transferFTSignedTransaction: async (
+          body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
+          testnet = false,
+          provider?: string,
+        ) => prepareTransferFTSignedTransaction(body, testnet, args.algoWeb, provider),
+        /**
+         * Sign ALgorand burn FT transaction with private key locally. Nothing is broadcast to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        burnFTSignedTransaction: async (
+          body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
+          testnet = false,
+          provider?: string,
+        ) => prepareBurnFTSignedTransaction(body, testnet, args.algoWeb, provider),
+      },
+      send: {
+        /**
+         * Send Algorand create FT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction id of the transaction in the blockchain.
+         */
+        createFTSignedTransaction: async (
+          body: DeployErc20 | DeployErc20KMS,
+          testnet = false,
+          provider?: string,
+        ) =>
+          BlockchainAlgorandAlgoService.algoandBroadcast({
+            txData: await prepareCreateFTSignedTransaction(body, testnet, args.algoWeb, provider),
+            ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
+          }),
+        /**
+         * Send Algorand transfer FT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction id of the transaction in the blockchain.
+         */
+        transferFTSignedTransaction: async (
+          body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
+          testnet = false,
+          provider?: string,
+        ) =>
+          BlockchainAlgorandAlgoService.algoandBroadcast({
+            txData: await prepareTransferFTSignedTransaction(body, testnet, args.algoWeb, provider),
+          }),
+        /**
+         * Sned Algorand burn FT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction id of the transaction in the blockchain.
+         */
+        burnFTSignedTransaction: async (
+          body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
+          testnet = false,
+          provider?: string,
+        ) =>
+          BlockchainAlgorandAlgoService.algoandBroadcast({
+            txData: await prepareBurnFTSignedTransaction(body, testnet, args.algoWeb, provider),
+            ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
+          }),
+      },
     },
-    send: {
-      /**
-       * Send Algorand transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * This operation is irreversible.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction id of the transaction in the blockchain
+
+    erc721: {
+      prepare: {
+        /**
+         * Sign Algorand create NFT transaction with private key locally. Nothing is broadcast to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction data to be broadcast to blockchain
+         */
+        createNFTSignedTransaction: async (
+          body: DeployNft | DeployNftKMS,
+          testnet = false,
+          provider?: string,
+        ) => prepareCreateNFTSignedTransaction(body, testnet, args.algoWeb, provider),
+        /**
+         * Sign Algorand transfer NFT transaction with private key locally. Nothing is broadcast to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        transferNFTSignedTransaction: async (
+          body: TransferNft | TransferNftKMS,
+          testnet = false,
+          provider?: string,
+        ) => prepareTransferNFTSignedTransaction(body, testnet, args.algoWeb, provider),
+        /**
+         * Sign Algorand burn NFT transaction with private key locally. Nothing is broadcast to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        burnNFTSignedTransaction: async (body: BurnNft | BurnNftKMS, testnet = false, provider?: string) =>
+          prepareBurnNFTSignedTransaction(body, testnet, args.algoWeb, provider),
+  
+      },
+      send: {
+  
+        /**
+         * Send Algorand create NFT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction id of the transaction in the blockchain
+         */
+        createNFTSignedTransaction: async (
+          body: DeployNft | DeployNftKMS,
+          testnet = false,
+          provider?: string,
+        ) =>
+          BlockchainAlgorandAlgoService.algoandBroadcast({
+            txData: await prepareCreateNFTSignedTransaction(body, testnet, args.algoWeb, provider),
+            ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
+          }),
+        /**
+         * Send Algorand Transfer NFT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction id of the transaction in the blockchain.
+         */
+        transferNFTSignedTransaction: async (
+          body: TransferNft | TransferNftKMS,
+          testnet = false,
+          provider?: string,
+        ) =>
+          BlockchainAlgorandAlgoService.algoandBroadcast({
+            txData: await prepareTransferNFTSignedTransaction(body, testnet, args.algoWeb, provider),
+            ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
+          }),
+        /**
+         * Send Algorand burn NFT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction id of the transaction in the blockchain.
+         */
+        burnNFTSignedTransaction: async (body: BurnNft | BurnNftKMS, testnet = false, provider?: string) =>
+          BlockchainAlgorandAlgoService.algoandBroadcast({
+            txData: await prepareBurnNFTSignedTransaction(body, testnet, args.algoWeb, provider),
+            ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
+          }),
+        
+      },
+    },
+
+    native: {
+      prepare: {
+        /**
+         * Algorand transaction signing
+         * @param testnet if the algorand node is testnet or not
+         * @param body content of the transaction to broadcast
+         * @param provider url of the algorand server endpoint for purestake.io restapi
+         * @returns transaction data to be broadcast to blockchain
        */
-      signedTransaction: async (body: TransferAlgo | TransferAlgoKMS, testnet = false, provider?: string) =>
+        signedTransaction: async (body: TransferAlgo | TransferAlgoKMS, testnet = false, provider?: string) =>
+         prepareSignedTransaction(body, testnet, args.algoWeb, provider),
+      },
+      send: {
+        /**
+         * Send Algorand transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * This operation is irreversible.
+         * @param testnet mainnet or testnet version
+         * @param body content of the transaction to broadcast
+         * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
+         * @returns transaction id of the transaction in the blockchain
+         */
+        signedTransaction: async (body: TransferAlgo | TransferAlgoKMS, testnet = false, provider?: string) =>
         BlockchainAlgorandAlgoService.algoandBroadcast({
           txData: await prepareSignedTransaction(body, testnet, args.algoWeb, provider),
           ...(isTransferAlgoKMS(body) && { signatureId: body.signatureId }),
         }),
-      /**
-       * Send Algorand create NFT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction id of the transaction in the blockchain
-       */
-      createNFTSignedTransaction: async (
-        body: DeployNft | DeployNftKMS,
-        testnet = false,
-        provider?: string,
-      ) =>
-        BlockchainAlgorandAlgoService.algoandBroadcast({
-          txData: await prepareCreateNFTSignedTransaction(body, testnet, args.algoWeb, provider),
-          ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
-        }),
-      /**
-       * Send Algorand Transfer NFT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction id of the transaction in the blockchain.
-       */
-      transferNFTSignedTransaction: async (
-        body: TransferNft | TransferNftKMS,
-        testnet = false,
-        provider?: string,
-      ) =>
-        BlockchainAlgorandAlgoService.algoandBroadcast({
-          txData: await prepareTransferNFTSignedTransaction(body, testnet, args.algoWeb, provider),
-          ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
-        }),
-      /**
-       * Send Algorand burn NFT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction id of the transaction in the blockchain.
-       */
-      burnNFTSignedTransaction: async (body: BurnNft | BurnNftKMS, testnet = false, provider?: string) =>
-        BlockchainAlgorandAlgoService.algoandBroadcast({
-          txData: await prepareBurnNFTSignedTransaction(body, testnet, args.algoWeb, provider),
-          ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
-        }),
-      /**
-       * Send Algorand create FT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction id of the transaction in the blockchain.
-       */
-      createFTSignedTransaction: async (
-        body: DeployErc20 | DeployErc20KMS,
-        testnet = false,
-        provider?: string,
-      ) =>
-        BlockchainAlgorandAlgoService.algoandBroadcast({
-          txData: await prepareCreateFTSignedTransaction(body, testnet, args.algoWeb, provider),
-          ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
-        }),
-      /**
-       * Send Algorand transfer FT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction id of the transaction in the blockchain.
-       */
-      transferFTSignedTransaction: async (
-        body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
-        testnet = false,
-        provider?: string,
-      ) =>
-        BlockchainAlgorandAlgoService.algoandBroadcast({
-          txData: await prepareTransferFTSignedTransaction(body, testnet, args.algoWeb, provider),
-        }),
-      /**
-       * Sned Algorand burn FT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * @param testnet mainnet or testnet version
-       * @param body content of the transaction to broadcast
-       * @param provider url of the Algorand Server to connect to. If not set, default public server will be used.
-       * @returns transaction id of the transaction in the blockchain.
-       */
-      burnFTSignedTransaction: async (
-        body: ChainTransferAlgoErc20 | ChainTransferAlgoErc20KMS,
-        testnet = false,
-        provider?: string,
-      ) =>
-        BlockchainAlgorandAlgoService.algoandBroadcast({
-          txData: await prepareBurnFTSignedTransaction(body, testnet, args.algoWeb, provider),
-          ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
-        }),
+      },
     },
   }
 }

--- a/packages/blockchain/algo/src/lib/services/algo.tx.ts
+++ b/packages/blockchain/algo/src/lib/services/algo.tx.ts
@@ -435,10 +435,8 @@ export const algoTx = (args: { algoWeb: AlgoWeb }) => {
          */
         burnNFTSignedTransaction: async (body: BurnNft | BurnNftKMS, testnet = false, provider?: string) =>
           prepareBurnNFTSignedTransaction(body, testnet, args.algoWeb, provider),
-  
       },
       send: {
-  
         /**
          * Send Algorand create NFT transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
          * @param testnet mainnet or testnet version
@@ -483,7 +481,6 @@ export const algoTx = (args: { algoWeb: AlgoWeb }) => {
             txData: await prepareBurnNFTSignedTransaction(body, testnet, args.algoWeb, provider),
             ...(isWithSignatureId(body) && { signatureId: body.signatureId }),
           }),
-        
       },
     },
 
@@ -495,9 +492,9 @@ export const algoTx = (args: { algoWeb: AlgoWeb }) => {
          * @param body content of the transaction to broadcast
          * @param provider url of the algorand server endpoint for purestake.io restapi
          * @returns transaction data to be broadcast to blockchain
-       */
+         */
         signedTransaction: async (body: TransferAlgo | TransferAlgoKMS, testnet = false, provider?: string) =>
-         prepareSignedTransaction(body, testnet, args.algoWeb, provider),
+          prepareSignedTransaction(body, testnet, args.algoWeb, provider),
       },
       send: {
         /**
@@ -509,10 +506,10 @@ export const algoTx = (args: { algoWeb: AlgoWeb }) => {
          * @returns transaction id of the transaction in the blockchain
          */
         signedTransaction: async (body: TransferAlgo | TransferAlgoKMS, testnet = false, provider?: string) =>
-        BlockchainAlgorandAlgoService.algoandBroadcast({
-          txData: await prepareSignedTransaction(body, testnet, args.algoWeb, provider),
-          ...(isTransferAlgoKMS(body) && { signatureId: body.signatureId }),
-        }),
+          BlockchainAlgorandAlgoService.algoandBroadcast({
+            txData: await prepareSignedTransaction(body, testnet, args.algoWeb, provider),
+            ...(isTransferAlgoKMS(body) && { signatureId: body.signatureId }),
+          }),
       },
     },
   }

--- a/packages/blockchain/bsc/src/lib/bsc.sdk.ts
+++ b/packages/blockchain/bsc/src/lib/bsc.sdk.ts
@@ -11,12 +11,18 @@ const blockchain = Blockchain.BSC
 export const TatumBscSDK = (args: SDKArguments) => {
   const web3 = bscWeb3({ blockchain })
   const api = BlockchainBscService
+  const txService = bscTxService({ blockchain, web3 });
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),
     api,
     kms: bscKmsService({ blockchain, web3 }),
-    transaction: bscTxService({ blockchain, web3 }),
+    transaction: txService.native,
+    erc20: txService.erc20,
+    erc721: txService.erc721,
+    smartContract: txService.smartContract,
+    multiToken: txService.multiToken,
+    custodial: txService.custodial,
     marketplace: evmBasedMarketplace({
       blockchain,
       web3,

--- a/packages/blockchain/bsc/src/lib/bsc.sdk.ts
+++ b/packages/blockchain/bsc/src/lib/bsc.sdk.ts
@@ -11,7 +11,7 @@ const blockchain = Blockchain.BSC
 export const TatumBscSDK = (args: SDKArguments) => {
   const web3 = bscWeb3({ blockchain })
   const api = BlockchainBscService
-  const txService = bscTxService({ blockchain, web3 });
+  const txService = bscTxService({ blockchain, web3 })
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),

--- a/packages/blockchain/celo/src/lib/celo.sdk.ts
+++ b/packages/blockchain/celo/src/lib/celo.sdk.ts
@@ -11,12 +11,16 @@ const blockchain = Blockchain.CELO
 export const TatumCeloSDK = (args: SDKArguments) => {
   const web3 = celoWeb3({ blockchain })
   const api = BlockchainCeloService
+  const txService = celoTxService({ blockchain })
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),
     api,
     kms: celoKmsService({ blockchain, web3 }),
-    transaction: celoTxService({ blockchain }),
+    transaction: celoTxService({ blockchain }), // @native after merge of pr
+    erc721: txService.erc721,
+    multiToken: txService.multiToken,
+    custodial: txService.custodial,
     httpDriver: async (request: Web3Request): Promise<Web3Response> => {
       return api.celoWeb3Driver(args.apiKey, { ...request, jsonrpc: '2.0' })
     },

--- a/packages/blockchain/eth/src/lib/eth.sdk.ts
+++ b/packages/blockchain/eth/src/lib/eth.sdk.ts
@@ -11,12 +11,18 @@ const blockchain = Blockchain.ETH
 export const TatumEthSDK = (args: SDKArguments) => {
   const web3 = ethWeb3({ blockchain })
   const api = BlockchainEthereumService
+  const txService = ethTx({ blockchain, web3 })
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),
     api,
     kms: ethKmsService({ blockchain, web3 }),
-    transaction: ethTx({ blockchain, web3 }),
+    transaction: txService.native,
+    erc20: txService.erc20,
+    erc721: txService.erc721,
+    multiToken: txService.multiToken,
+    smartContract: txService.smartContract,
+    custodial: txService.custodial,
     marketplace: evmBasedMarketplace({
       blockchain,
       web3,

--- a/packages/blockchain/kcs/src/lib/kcs.sdk.ts
+++ b/packages/blockchain/kcs/src/lib/kcs.sdk.ts
@@ -11,12 +11,17 @@ const blockchain = Blockchain.KCS
 export const TatumKcsSDK = (args: SDKArguments) => {
   const web3 = kcsWeb3({ blockchain })
   const api = BlockchainKcsKcsService
+  const txService = kcsTxService({ blockchain, web3 })
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),
     api,
     kms: kcsKmsService({ blockchain, web3 }),
-    transaction: kcsTxService({ blockchain, web3 }),
+    transaction: txService.native,
+    erc20: txService.erc20,
+    erc721: txService.erc721,
+    multiToken: txService.multiToken,
+    smartContract: txService.smartContract,
     httpDriver: async (request: Web3Request): Promise<Web3Response> => {
       return api.kcsWeb3Driver(args.apiKey, { ...request, jsonrpc: '2.0' })
     },

--- a/packages/blockchain/klaytn/src/lib/sdk-klaytn.ts
+++ b/packages/blockchain/klaytn/src/lib/sdk-klaytn.ts
@@ -10,11 +10,15 @@ const blockchain = Blockchain.KLAY
 
 export const TatumKlaytnSDK = (args: SDKArguments) => {
   const web3 = klaytnWeb3({ blockchain })
+  const txService = klaytnTxService({ blockchain, web3 })
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),
     kms: klaytnKmsService({ blockchain, web3 }),
-    transaction: klaytnTxService({ blockchain, web3 }),
+    transaction: txService.native,
+    erc20: txService.erc20,
+    erc721: txService.erc721,
+    multiToken: txService.multiToken,
     marketplace: {
       ...evmBasedMarketplace({
         blockchain,

--- a/packages/blockchain/one/src/lib/one.sdk.ts
+++ b/packages/blockchain/one/src/lib/one.sdk.ts
@@ -11,12 +11,18 @@ const blockchain = Blockchain.HARMONY
 export const TatumOneSDK = (args: SDKArguments) => {
   const web3 = oneWeb3({ blockchain })
   const api = BlockchainHarmonyOneService
+  const txService = oneTxService({ blockchain, web3 })
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),
     api,
     kms: oneKmsService({ blockchain, web3 }),
-    transaction: oneTxService({ blockchain, web3 }),
+    transaction: txService.native,
+    erc20: txService.erc20,
+    erc721: txService.erc721,
+    multiToken: txService.multiToken,
+    smartContract: txService.smartContract,
+    custodial: txService.custodial,
     marketplace: evmBasedMarketplace({
       blockchain,
       web3,

--- a/packages/blockchain/polygon/src/lib/polygon.sdk.ts
+++ b/packages/blockchain/polygon/src/lib/polygon.sdk.ts
@@ -11,12 +11,18 @@ const blockchain = Blockchain.POLYGON
 export const TatumPolygonSDK = (args: SDKArguments) => {
   const web3 = polygonWeb3({ blockchain })
   const api = BlockchainPolygonMaticService
+  const txService = polygonTxService({ blockchain, web3 })
 
   return {
     ...evmBasedSdk({ ...args, blockchain, web3 }),
     api,
     kms: polygonKmsService({ blockchain, web3 }),
-    transaction: polygonTxService({ blockchain, web3 }),
+    transaction: txService.native,
+    erc20: txService.erc20,
+    erc721: txService.erc721,
+    multiToken: txService.multiToken,
+    smartContract: txService.smartContract,
+    custodial: txService.custodial,
     marketplace: evmBasedMarketplace({
       blockchain,
       web3,

--- a/packages/blockchain/tron/src/lib/services/tron.tx.ts
+++ b/packages/blockchain/tron/src/lib/services/tron.tx.ts
@@ -223,11 +223,11 @@ export const tronTx = (args: { tronWeb: ITronWeb }) => {
     native: {
       prepare: {
         /**
-        * Sign Tron transaction with private keys locally. Nothing is broadcast to the blockchain.
-        * @param body content of the transaction to broadcast
-        * @param provider
-        * @returns transaction data to be broadcast to blockchain.
-        */
+         * Sign Tron transaction with private keys locally. Nothing is broadcast to the blockchain.
+         * @param body content of the transaction to broadcast
+         * @param provider
+         * @returns transaction data to be broadcast to blockchain.
+         */
         signedTransaction: async (
           body: TransferTronBlockchain | TransferTronBlockchainKMS,
           provider?: string,
@@ -239,7 +239,7 @@ export const tronTx = (args: { tronWeb: ITronWeb }) => {
          * @returns transaction data to be broadcast to blockchain.
          */
         freezeTransaction: async (body: FreezeTron | FreezeTronKMS, provider?: string) =>
-        prepareFreezeTransaction(body, args.tronWeb, provider),
+          prepareFreezeTransaction(body, args.tronWeb, provider),
       },
       send: {
         /**
@@ -252,10 +252,10 @@ export const tronTx = (args: { tronWeb: ITronWeb }) => {
           body: TransferTronBlockchain | TransferTronBlockchainKMS,
           provider?: string,
         ) =>
-        BlockchainTronService.tronBroadcast({
+          BlockchainTronService.tronBroadcast({
             txData: await prepareSignedTransaction(body, args.tronWeb, provider),
             // TODO: SignatureID is missing in OpenApi
-        }),
+          }),
         /**
          * Send Tron Freeze balance transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
          * This operation is irreversible.
@@ -263,10 +263,10 @@ export const tronTx = (args: { tronWeb: ITronWeb }) => {
          * @returns transaction id of the transaction in the blockchain
          */
         freezeTransaction: async (body: FreezeTron | FreezeTronKMS, provider?: string) =>
-        BlockchainTronService.tronBroadcast({
-          txData: await prepareFreezeTransaction(body, args.tronWeb, provider),
-          // TODO: SignatureID is missing in OpenApi
-        }),
+          BlockchainTronService.tronBroadcast({
+            txData: await prepareFreezeTransaction(body, args.tronWeb, provider),
+            // TODO: SignatureID is missing in OpenApi
+          }),
       },
     },
     smartContract: {
@@ -317,10 +317,10 @@ export const tronTx = (args: { tronWeb: ITronWeb }) => {
           body: GenerateCustodialWalletTron | GenerateCustodialWalletTronKMS,
           provider?: string,
         ) =>
-        BlockchainTronService.tronBroadcast({
-          txData: await prepareGenerateCustodialWalletSignedTransaction(body, args.tronWeb, provider),
-          // TODO: SignatureID is missing in OpenApi
-        }),
+          BlockchainTronService.tronBroadcast({
+            txData: await prepareGenerateCustodialWalletSignedTransaction(body, args.tronWeb, provider),
+            // TODO: SignatureID is missing in OpenApi
+          }),
       },
     },
     marketplace: {
@@ -354,6 +354,6 @@ export const tronTx = (args: { tronWeb: ITronWeb }) => {
             // TODO: SignatureID is missing in OpenApi
           }),
       },
-    }
+    },
   }
 }

--- a/packages/blockchain/tron/src/lib/services/tron.tx.ts
+++ b/packages/blockchain/tron/src/lib/services/tron.tx.ts
@@ -220,122 +220,140 @@ export const tronTx = (args: { tronWeb: ITronWeb }) => {
     trc10: tronTrc10(args),
     trc20: tronTrc20(args),
     trc721: tronTrc721(args),
-    prepare: {
-      /**
-       * Sign Tron transaction with private keys locally. Nothing is broadcast to the blockchain.
-       * @param body content of the transaction to broadcast
-       * @param provider
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      signedTransaction: async (
-        body: TransferTronBlockchain | TransferTronBlockchainKMS,
-        provider?: string,
-      ) => prepareSignedTransaction(body, args.tronWeb, provider),
-      /**
-       * Sign Tron Freeze balance transaction with private keys locally. Nothing is broadcast to the blockchain.
-       * @param body content of the transaction to broadcast
-       * @param provider optional provider to enter. if not present, Tatum provider will be used.
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      freezeTransaction: async (body: FreezeTron | FreezeTronKMS, provider?: string) =>
+    native: {
+      prepare: {
+        /**
+        * Sign Tron transaction with private keys locally. Nothing is broadcast to the blockchain.
+        * @param body content of the transaction to broadcast
+        * @param provider
+        * @returns transaction data to be broadcast to blockchain.
+        */
+        signedTransaction: async (
+          body: TransferTronBlockchain | TransferTronBlockchainKMS,
+          provider?: string,
+        ) => prepareSignedTransaction(body, args.tronWeb, provider),
+        /**
+         * Sign Tron Freeze balance transaction with private keys locally. Nothing is broadcast to the blockchain.
+         * @param body content of the transaction to broadcast
+         * @param provider optional provider to enter. if not present, Tatum provider will be used.
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        freezeTransaction: async (body: FreezeTron | FreezeTronKMS, provider?: string) =>
         prepareFreezeTransaction(body, args.tronWeb, provider),
-      /**
-       * Sign Tron custodial transfer transaction with private keys locally. Nothing is broadcast to the blockchain.
-       * @param body content of the transaction to broadcast
-       * @param provider
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      smartContractInvocation: async (
-        body: CallSmartContractMethod | CallSmartContractMethodKMS,
-        provider?: string,
-      ) => prepareSmartContractInvocation(body, args.tronWeb, provider),
-      /**
-       * Sign Tron custodial transfer batch transaction with private keys locally. Nothing is broadcast to the blockchain.
-       * @param body content of the transaction to broadcast
-       * @param provider
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      custodialTransferBatch: async (
-        body: CallSmartContractMethod | CallSmartContractMethodKMS,
-        provider?: string,
-      ) => prepareCustodialTransferBatch(body, args.tronWeb, provider),
-      /**
-       * Sign Tron generate custodial wallet transaction with private keys locally. Nothing is broadcast to the blockchain.
-       * @param body content of the transaction to broadcast
-       * @param provider
-       * @returns transaction data to be broadcast to blockchain.
-       */
-      generateCustodialWalletSignedTransaction: async (
-        body: GenerateCustodialWalletTron | GenerateCustodialWalletTronKMS,
-        provider?: string,
-      ) => prepareGenerateCustodialWalletSignedTransaction(body, args.tronWeb, provider),
-      /**
-       * Sign TRON deploy new smart contract for NFT marketplace transaction. Smart contract enables marketplace operator to create new listing for NFT (ERC-721/1155).
-       * @param body request data
-       * @param provider optional provider to enter. if not present, Tatum provider will be used.
-       * @returns {txId: string} Transaction ID of the operation, or signatureID in case of Tatum KMS
-       */
-      deployMarketplaceListingSignedTransaction: async (
-        body: GenerateMarketplaceTron | GenerateMarketplaceTronKMS,
-        tronWeb: ITronWeb,
-        provider?: string,
-      ) => prepareDeployMarketplaceListingSignedTransaction(body, args.tronWeb, provider),
-    },
-    send: {
-      /**
-       * Send Tron transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * This operation is irreversible.
-       * @param body content of the transaction to broadcast
-       * @returns transaction id of the transaction in the blockchain
-       */
-      signedTransaction: async (
-        body: TransferTronBlockchain | TransferTronBlockchainKMS,
-        provider?: string,
-      ) =>
+      },
+      send: {
+        /**
+         * Send Tron transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * This operation is irreversible.
+         * @param body content of the transaction to broadcast
+         * @returns transaction id of the transaction in the blockchain
+         */
+        signedTransaction: async (
+          body: TransferTronBlockchain | TransferTronBlockchainKMS,
+          provider?: string,
+        ) =>
         BlockchainTronService.tronBroadcast({
-          txData: await prepareSignedTransaction(body, args.tronWeb, provider),
-          // TODO: SignatureID is missing in OpenApi
+            txData: await prepareSignedTransaction(body, args.tronWeb, provider),
+            // TODO: SignatureID is missing in OpenApi
         }),
-      /**
-       * Send Tron Freeze balance transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * This operation is irreversible.
-       * @param body content of the transaction to broadcast
-       * @returns transaction id of the transaction in the blockchain
-       */
-      freezeTransaction: async (body: FreezeTron | FreezeTronKMS, provider?: string) =>
+        /**
+         * Send Tron Freeze balance transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * This operation is irreversible.
+         * @param body content of the transaction to broadcast
+         * @returns transaction id of the transaction in the blockchain
+         */
+        freezeTransaction: async (body: FreezeTron | FreezeTronKMS, provider?: string) =>
         BlockchainTronService.tronBroadcast({
           txData: await prepareFreezeTransaction(body, args.tronWeb, provider),
           // TODO: SignatureID is missing in OpenApi
         }),
-      /**
-       * Send Tron generate custodial wallet transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
-       * This operation is irreversible.
-       * @param body content of the transaction to broadcast
-       * @returns transaction id of the transaction in the blockchain
-       */
-      generateCustodialWalletSignedTransaction: async (
-        body: GenerateCustodialWalletTron | GenerateCustodialWalletTronKMS,
-        provider?: string,
-      ) =>
+      },
+    },
+    smartContract: {
+      prepare: {
+        /**
+         * Sign Tron custodial transfer transaction with private keys locally. Nothing is broadcast to the blockchain.
+         * @param body content of the transaction to broadcast
+         * @param provider
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        smartContractInvocation: async (
+          body: CallSmartContractMethod | CallSmartContractMethodKMS,
+          provider?: string,
+        ) => prepareSmartContractInvocation(body, args.tronWeb, provider),
+      },
+    },
+    custodial: {
+      prepare: {
+        /**
+         * Sign Tron custodial transfer batch transaction with private keys locally. Nothing is broadcast to the blockchain.
+         * @param body content of the transaction to broadcast
+         * @param provider
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        custodialTransferBatch: async (
+          body: CallSmartContractMethod | CallSmartContractMethodKMS,
+          provider?: string,
+        ) => prepareCustodialTransferBatch(body, args.tronWeb, provider),
+        /**
+         * Sign Tron generate custodial wallet transaction with private keys locally. Nothing is broadcast to the blockchain.
+         * @param body content of the transaction to broadcast
+         * @param provider
+         * @returns transaction data to be broadcast to blockchain.
+         */
+        generateCustodialWalletSignedTransaction: async (
+          body: GenerateCustodialWalletTron | GenerateCustodialWalletTronKMS,
+          provider?: string,
+        ) => prepareGenerateCustodialWalletSignedTransaction(body, args.tronWeb, provider),
+      },
+      send: {
+        /**
+         * Send Tron generate custodial wallet transaction to the blockchain. This method broadcasts signed transaction to the blockchain.
+         * This operation is irreversible.
+         * @param body content of the transaction to broadcast
+         * @returns transaction id of the transaction in the blockchain
+         */
+        generateCustodialWalletSignedTransaction: async (
+          body: GenerateCustodialWalletTron | GenerateCustodialWalletTronKMS,
+          provider?: string,
+        ) =>
         BlockchainTronService.tronBroadcast({
           txData: await prepareGenerateCustodialWalletSignedTransaction(body, args.tronWeb, provider),
           // TODO: SignatureID is missing in OpenApi
         }),
-      /**
-       * Deploy new smart contract for NFT marketplace logic. Smart contract enables marketplace operator to create new listing for NFT (ERC-721/1155).
-       * @param body request data
-       * @param provider optional provider to enter. if not present, Tatum provider will be used.
-       * @returns {txId: string} Transaction ID of the operation, or signatureID in case of Tatum KMS
-       */
-      deployMarketplaceListingSignedTransaction: async (
-        body: GenerateMarketplaceTron | GenerateMarketplaceTronKMS,
-        tronWeb: ITronWeb,
-        provider?: string,
-      ) =>
-        BlockchainTronService.tronBroadcast({
-          txData: await prepareDeployMarketplaceListingSignedTransaction(body, args.tronWeb, provider),
-          // TODO: SignatureID is missing in OpenApi
-        }),
+      },
     },
+    marketplace: {
+      prepare: {
+        /**
+         * Sign TRON deploy new smart contract for NFT marketplace transaction. Smart contract enables marketplace operator to create new listing for NFT (ERC-721/1155).
+         * @param body request data
+         * @param provider optional provider to enter. if not present, Tatum provider will be used.
+         * @returns {txId: string} Transaction ID of the operation, or signatureID in case of Tatum KMS
+         */
+        deployMarketplaceListingSignedTransaction: async (
+          body: GenerateMarketplaceTron | GenerateMarketplaceTronKMS,
+          tronWeb: ITronWeb,
+          provider?: string,
+        ) => prepareDeployMarketplaceListingSignedTransaction(body, args.tronWeb, provider),
+      },
+      send: {
+        /**
+         * Deploy new smart contract for NFT marketplace logic. Smart contract enables marketplace operator to create new listing for NFT (ERC-721/1155).
+         * @param body request data
+         * @param provider optional provider to enter. if not present, Tatum provider will be used.
+         * @returns {txId: string} Transaction ID of the operation, or signatureID in case of Tatum KMS
+         */
+        deployMarketplaceListingSignedTransaction: async (
+          body: GenerateMarketplaceTron | GenerateMarketplaceTronKMS,
+          tronWeb: ITronWeb,
+          provider?: string,
+        ) =>
+          BlockchainTronService.tronBroadcast({
+            txData: await prepareDeployMarketplaceListingSignedTransaction(body, args.tronWeb, provider),
+            // TODO: SignatureID is missing in OpenApi
+          }),
+      },
+    }
   }
 }

--- a/packages/blockchain/tron/src/lib/tron.sdk.ts
+++ b/packages/blockchain/tron/src/lib/tron.sdk.ts
@@ -11,13 +11,20 @@ const blockchain = Blockchain.TRON
 
 export const TatumTronSDK = (args: SDKArguments) => {
   const web = tronWeb()
+  const txService = tronTx({ tronWeb: web })
 
   return {
     ...abstractBlockchainSdk({
       ...args,
       blockchain,
     }),
-    transaction: tronTx({ tronWeb: web }),
+    transaction: txService.native,
+    trc10: txService.trc10,
+    trc20: txService.trc20,
+    trc721: txService.trc721,
+    marketplace: txService.marketplace,
+    smartContract: txService.smartContract,
+    custodial: txService.custodial,
     wallet: tronWallet({ tronWeb: web }),
     tronWeb: web,
     record: tronRecord(),


### PR DESCRIPTION
Distributes SDK paths to top level, re-organizes Algo+Tron  
  
eg. from:  
`const test= await tatumSDK.blockchain.one.transaction.erc20.send.deploySignedTransaction`  
  
to:  
`const test= await tatumSDK.blockchain.one.erc20.send.deploySignedTransaction`