### PR TITLE
fix(egld): proper tx value cast to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "Tatum API client allows browsers and Node.js clients to interact with Tatum API.",
   "main": "dist/src/index.js",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/transaction/egld.ts
+++ b/src/transaction/egld.ts
@@ -362,7 +362,7 @@ const prepareSignedTransactionAbstraction = async (
 
     const egldTx: EgldSendTransaction = {
         nonce,
-        value: new BigNumber(transaction.value as string).isLessThan(0) ? '0' : new BigNumber(transaction.value as string).multipliedBy(1e18).toString(),
+        value: new BigNumber(transaction.value as string).isLessThan(0) ? '0' : new BigNumber(transaction.value as string).multipliedBy(1e18).toFixed(),
         receiver: transaction.to as string,
         sender,
         gasPrice,


### PR DESCRIPTION
If the transaction value is greater than or equal to 1000, then after multiplying by 10^18, the toString() function will represent the number in exponential notation (1e+21), which the EGLD REST API does not support