### PR TITLE
fix(solana): nft metadata validation

### DIFF
--- a/packages/tatum-solana/src/model/request/solana/SolanaNftMetadata.ts
+++ b/packages/tatum-solana/src/model/request/solana/SolanaNftMetadata.ts
@@ -1,22 +1,24 @@
 import { Type } from 'class-transformer'
-import { IsArray, IsNotEmpty, IsNumber, MaxLength, ValidateIf, ValidateNested } from 'class-validator'
+import {IsArray, IsNotEmpty, IsNumber, Max, MaxLength, Min, ValidateIf, ValidateNested} from 'class-validator'
 import { SolanaNftMetadataCreator } from './SolanaNftMetadataCreator'
 
 export class SolanaNftMetadata {
   @IsNotEmpty()
-  @MaxLength(255)
+  @MaxLength(32)
   public name: string
 
   @IsNotEmpty()
-  @MaxLength(255)
+  @MaxLength(10)
   public symbol: string
 
   @IsNotEmpty()
-  @MaxLength(500)
+  @MaxLength(200)
   public uri: string
 
   @IsNotEmpty()
   @IsNumber()
+  @Min(0)
+  @Max(10000)
   public sellerFeeBasisPoints: number
 
   @Type(() => SolanaNftMetadataCreator)


### PR DESCRIPTION
The constants for validating the fields were not quite right. I changed them according to the metaplex token-metadata code. 

Validation code: [Click](https://github.com/metaplex-foundation/metaplex-program-library/blob/408455ddd14764e3e992759ab4258db7a1ffed09/token-metadata/program/src/utils.rs#L40)

Constants: [Click](https://github.com/metaplex-foundation/metaplex-program-library/blob/4f01643bd3931b88bc0e0850334e5cee31996122/token-metadata/program/src/state.rs#L21)