### PR TITLE
PLT-108 - generate bech32 only [V1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "1.34.5",
+  "version": "1.34.6",
   "description": "Tatum API client allows browsers and Node.js clients to interact with Tatum API.",
   "main": "dist/src/index.js",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/wallet/address.spec.ts
+++ b/src/wallet/address.spec.ts
@@ -43,12 +43,7 @@ describe('Address tests', () => {
     expect(address).toBe('968c3ce11e871cb2b7161b282655ee5fcb051f3c04894705d771bf11c6fbebfc6556ab8a0c04f45ea56281312336d0668529077c9d66891a6cad3db877acbe90')
   })
 
-  it('should generate P2SH address 1 for BTC testnet', () => {
-    const address = generateAddressFromXPub(Currency.BTC, true, 'tpubDFjLw3ykn4aB7fFt96FaqRjSnvtDsU2wpVr8GQk3Eo612LS9jo9JgMkQRfYVG248J3pTBsxGg3PYUXFd7pReNLTeUzxFcUDL3zCvrp3H34a', 1, 'p2sh')
-    expect(address).toBe('mjJotvHmzEuyXZJGJXXknS6N3PWQnw6jf5')
-  })
-
-  it('should generate BECH32 address 1 for BTC testnet', () => {
+  it('should generate address 1 for BTC testnet', () => {
     const address = generateAddressFromXPub(Currency.BTC, true, 'tpubDFjLw3ykn4aB7fFt96FaqRjSnvtDsU2wpVr8GQk3Eo612LS9jo9JgMkQRfYVG248J3pTBsxGg3PYUXFd7pReNLTeUzxFcUDL3zCvrp3H34a', 1)
     expect(address).toBe('tb1q9x2gqftyxterwt0k6ehzrm2gkzthjly677ucyr')
   })

--- a/src/wallet/address.ts
+++ b/src/wallet/address.ts
@@ -72,14 +72,10 @@ interface Decoded extends Hash {
  * @param i derivation index of address to generate. Up to 2^31 addresses can be generated.
  * @returns blockchain address
  */
-const generateBtcAddress = (testnet: boolean, xpub: string, i: number, addressType: 'p2sh' | 'bech32' = 'bech32') => {
+const generateBtcAddress = (testnet: boolean, xpub: string, i: number) => {
   const network = testnet ? networks.testnet : networks.bitcoin
   const w = fromBase58(xpub, network).derivePath(String(i))
-  if (addressType === 'bech32') {
-    return payments.p2wpkh({ pubkey: w.publicKey, network }).address as string
-  } else {
-    return payments.p2pkh({ pubkey: w.publicKey, network }).address as string
-  }
+  return payments.p2wpkh({ pubkey: w.publicKey, network }).address as string
 }
 
 /**
@@ -668,10 +664,10 @@ export const generateAlgodAddressFromPrivatetKey = (privKey: string) => {
  * @param i derivation index of address to generate. Up to 2^31 addresses can be generated.
  * @returns blockchain address
  */
-export const generateAddressFromXPub = (currency: Currency, testnet: boolean, xpub: string, i: number, addressType?: 'p2sh' | 'bech32') => {
+export const generateAddressFromXPub = (currency: Currency, testnet: boolean, xpub: string, i: number) => {
   switch (currency) {
     case Currency.BTC:
-      return generateBtcAddress(testnet, xpub, i, addressType)
+      return generateBtcAddress(testnet, xpub, i)
     case Currency.TRON:
     case Currency.USDT_TRON:
     case Currency.INRT_TRON:


### PR DESCRIPTION
Removes p2sh btc address option to generate bech32 only, adds version bump