### PR TITLE
Updated Decode Function in toLegacyAddress function

### DIFF
--- a/packages/blockchain/bch/src/lib/services/bch.sdk.tx.ts
+++ b/packages/blockchain/bch/src/lib/services/bch.sdk.tx.ts
@@ -79,7 +79,7 @@ export const bchTransactions = (apiCalls: BchApiCallsType) => {
         try {
           transactionBuilder.addOutput(bcashAddressHelper.getAddress(body.changeAddress), change)
         } catch (e: any) {
-          const address = new bitcoreLibCash.Address.fromString(body.changeAddress)
+          const address = Address.fromString(body.changeAddress)
           transactionBuilder.addOutput(address.toLegacyAddress(), change)
         }
       }

--- a/packages/blockchain/bch/src/lib/utils/bch.address.ts
+++ b/packages/blockchain/bch/src/lib/utils/bch.address.ts
@@ -4,6 +4,8 @@ import coininfo from 'coininfo'
 import bcash from '@tatumio/bitcoincashjs2-lib'
 import { networks } from 'bitcoinjs-lib'
 import { Buffer } from 'buffer'
+import cashaddr from 'cashaddrjs';
+
 
 interface Hash {
   hash: Buffer
@@ -28,7 +30,7 @@ export const bcashAddressHelper = {
     }
   },
   toLegacyAddress: (address: string) => {
-    const { prefix, type, hash }: Decoded = bcashAddressHelper.decode(address)
+    const { prefix, type, hash }: Decoded = cashaddr.decode(address)
     let bitcoincash = coininfo.bitcoincash.main
     switch (prefix) {
       case 'bitcoincash':


### PR DESCRIPTION
Due to the error reported in #303, the current decode function is failing and defaults to using `new Address.fromString(address).toLegacyAddress(address)` the right way to call it is without new, so `Address.fromString().toLegacyAddress()` the resulting value returned here sometimes does not work with mainnet.

So updating the `decode` function called in the `toLegacyAddress` to the decode method coming from `cashaddrjs`