### PR TITLE
ALL-1688 Add fee submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.4.25] - 2023.06.19
+
+### Added
+- Added new module for getting current fee for Evm and Utxo chains. 
+### Changed
+- Refactoring TatumSdk class to return specific blockchain class on `init` instead of one generic class.
+
 ## [1.4.24] - 2023.06.12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,21 +32,23 @@ Tatum SDK is a powerful, feature-rich TypeScript/JavaScript library that streaml
 
 With Tatum SDK, you can:
 
-* Perform native RPC calls: Easily interact with different blockchains through native RPC calls, abstracting away the complexities of managing separate RPC clients for each blockchain.
-* Create notifications: Monitor wallet activity with ease by setting up real-time notifications for events such as incoming and outgoing transactions, balance updates, and contract interactions.
-* Access wallet information: Retrieve vital wallet details, including balances, transaction history, and other relevant information, all through a single interface.
-And much more: Tatum SDK is constantly evolving, with new features and support for additional blockchains being added regularly.
-This comprehensive library is the ideal choice for developers who are keen on building robust, scalable, and efficient blockchain applications without getting bogged down by the intricacies of working with multiple blockchain protocols.
+- Perform native RPC calls: Easily interact with different blockchains through native RPC calls, abstracting away the complexities of managing separate RPC clients for each blockchain.
+- Create notifications: Monitor wallet activity with ease by setting up real-time notifications for events such as incoming and outgoing transactions, balance updates, and contract interactions.
+- Access wallet information: Retrieve vital wallet details, including balances, transaction history, and other relevant information, all through a single interface.
+  And much more: Tatum SDK is constantly evolving, with new features and support for additional blockchains being added regularly.
+  This comprehensive library is the ideal choice for developers who are keen on building robust, scalable, and efficient blockchain applications without getting bogged down by the intricacies of working with multiple blockchain protocols.
 
 This guide will walk you through the basic setup, installation, and usage of TatumSDK to help you harness the full potential of this library.
 
 ## Prerequisites
+
 Before diving into TatumSDK, ensure that you have the following prerequisites installed:
 
-* **Node.js**: Ensure you have the latest LTS version installed.
-* **npm**: npm is bundled with Node.js, so installing Node.js should automatically install npm.
+- **Node.js**: Ensure you have the latest LTS version installed.
+- **npm**: npm is bundled with Node.js, so installing Node.js should automatically install npm.
 
 ## Installation
+
 To install TatumSDK, simply run the following command in your terminal or command prompt:
 
 ### Install using [npm](https://www.npmjs.com/)
@@ -70,46 +72,39 @@ pnpm install @tatumcom/js
 ## Getting started
 
 ### Basic Usage
+
 Here's a brief overview of how to utilize TatumSDK for RPC calls and subscribing to notifications.
 
 ### Initialization
+
 Start by importing the TatumSDK library and initializing Ethereum client as follows:
 
 ```ts
-import {
-  TatumSDK,
-  Network,
-  Ethereum,
-} from '@tatumcom/js'
+import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 ```
 
 ### RPC Calls
+
 To make RPC calls, use the available methods to interact with Ethereum blockchain. For example, to fetch the balance of a specific Ethereum address:
 
 ```ts
-import {
-  TatumSDK,
-  Network,
-  Ethereum,
-} from '@tatumcom/js'
+import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 
-const balance = await tatum.rpc.getBalance('0x742d35Cc6634C0532925a3b844Bc454e4438f44e');
-console.log(`Balance: ${balance}`);
+const balance = await tatum.rpc.getBalance('0x742d35Cc6634C0532925a3b844Bc454e4438f44e')
+console.log(`Balance: ${balance}`)
 ```
+
 ### Subscribing to Notifications
+
 To subscribe to notifications for events related to a specified Ethereum address, choose a type of event you want to be notified about.
 We are going to use `addressEvent` as an example, which sends you notification about any transfer on the address - native ones, ERC20 tokens or NFTs. To subscribe to this event, use the following code:
 
 ```ts
-import {
-  TatumSDK,
-  Network,
-  Ethereum,
-} from '@tatumcom/js'
+import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 
@@ -123,15 +118,11 @@ console.log(response)
 ```
 
 ### Get NFT balance of a wallet
+
 Using TatumSDK, obtain the NFT balance of an address by calling the getNFTBalance method within the NFT submodule and passing the target address as an argument. This streamlined process efficiently retrieves the total number of NFTs owned by the specified address. To achieve this, use the following code:
 
 ```ts
-import {
-  TatumSDK,
-  Network,
-  Ethereum,
-  NftAddressBalance
-} from '@tatumcom/js'
+import { TatumSDK, Network, Ethereum, NftAddressBalance } from '@tatumcom/js'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 
@@ -143,54 +134,97 @@ console.log(balances)
 ```
 
 ### Connect to MetaMask and send transaction
+
 Using TatumSDK, it's possible to connect your browser application to MetaMask and perform transactions using it. To achieve this, use the following code:
 
 ```ts
-import {
-  TatumSDK,
-  Network,
-  Ethereum,
-} from '@tatumcom/js'
+import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 
 const account: string = await tatum.walletProvider.metaMask.connect()
-const txId: string = await tatum.walletProvider.metaMask.transferNative('0x53e8577C4347C365E4e0DA5B57A589cB6f2AB848', '1')
+const txId: string = await tatum.walletProvider.metaMask.transferNative(
+  '0x53e8577C4347C365E4e0DA5B57A589cB6f2AB848',
+  '1',
+)
 
 console.log(txId)
 ```
 
 ### Get exchange rates
+
 Using TatumSDK, obtain current fiat/crypto exchange rates To achieve this, use the following code:
 
 ```ts
-import {
-  TatumSDK,
-  Network,
-  Ethereum,
-} from '@tatumcom/js'
+import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 
-const res = await tatum.rates.getCurrentRate("BTC","EUR");
+const res = await tatum.rates.getCurrentRate('BTC', 'EUR')
 
 console.log(res.data)
 ```
 
+### Get current fees
+
+Using TatumSDK, you can obtain recommended fee/gas price for a blockchain. Supported blockchains are:
+
+- `Bitcoin`
+- `Litecoin`
+- `Dogecoin`
+- `Ethereum`
+
+```ts
+import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
+
+const tatum = await TatumSDK.init<Ethereum>({
+  network: Network.ETHEREUM_SEPOLIA,
+  verbose: true,
+  retryDelay: 1000,
+  retryCount: 2,
+  version: ApiVersion.V1,
+})
+
+const result = await tatum.fee.getCurrentFee()
+
+console.log(result.data)
+```
+
+### Get token balance
+
+Using TatumSDK, obtain all fungible token balances of an address by calling the getBalance method within the `token` submodule and passing the target address as an argument. This streamlined process efficiently retrieves all balances for fungible tokens that specified address holds. To achieve this, use the following code:
+
+```ts
+import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
+
+const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM_SEPOLIA })
+
+const { data: balances } = await tatum.token.getBalance({
+  addresses: ['0x2cbaf358c0af93096bd820ce57c26f0b7c6ec7ab'],
+})
+
+console.log(balances)
+```
+
 ## Structure of the SDK
+
 TatumSDK is thoughtfully designed and organized into these submodules to provide a clean and efficient way of interacting with blockchains:
 
-* **RPC submodule - `tatum.rpc.*`**: This submodule enables you to make direct Remote Procedure Call (RPC) calls to multiple blockchains, providing seamless access to various on-chain data and functionalities. With the RPC submodule, you can fetch account balances, send transactions, interact with smart contracts, and more.
+- **RPC submodule - `tatum.rpc.*`**: This submodule enables you to make direct Remote Procedure Call (RPC) calls to multiple blockchains, providing seamless access to various on-chain data and functionalities. With the RPC submodule, you can fetch account balances, send transactions, interact with smart contracts, and more.
 
-* **Notification submodule - `tatum.notification.*`**: This submodule allows you to subscribe to real-time notifications for a wide range of events related to specified blockchain addresses. By leveraging the notification submodule, you can effortlessly track incoming and outgoing transactions, NFT transfers, and other events without constantly polling the blockchain.
+- **Notification submodule - `tatum.notification.*`**: This submodule allows you to subscribe to real-time notifications for a wide range of events related to specified blockchain addresses. By leveraging the notification submodule, you can effortlessly track incoming and outgoing transactions, NFT transfers, and other events without constantly polling the blockchain.
 
-* **NFT submodule - `tatum.nft.*`**: This submodule offers a comprehensive suite of tools for working with Non-Fungible Tokens (NFTs). With the NFT submodule, you can query the balance of NFTs on an address, retrieve NFT transactions associated with a specific address, explore NFTs within a collection or identify the owners of a particular NFT.
+- **NFT submodule - `tatum.nft.*`**: This submodule offers a comprehensive suite of tools for working with Non-Fungible Tokens (NFTs). With the NFT submodule, you can query the balance of NFTs on an address, retrieve NFT transactions associated with a specific address, explore NFTs within a collection or identify the owners of a particular NFT.
 
-* **Address submodule - `tatum.address.*`**: This submodule simplifies wallet management across multiple blockchains by allowing you to fetch wallet balances and retrieve transactions for a given address. With the Address submodule, you can easily manage your wallets and monitor transactions, making your blockchain application development more efficient and user-friendly.
+- **Address submodule - `tatum.address.*`**: This submodule simplifies wallet management across multiple blockchains by allowing you to fetch wallet balances and retrieve transactions for a given address. With the Address submodule, you can easily manage your wallets and monitor transactions, making your blockchain application development more efficient and user-friendly.
 
-* **Wallet Provider submodule - `tatum.walletProvider.*`**: This submodule enables seamless interaction with external wallets like Metamask or Phantom within the browser. The Wallet Provider submodule allows the SDK to communicate with various wallet providers, streamlining the process of signing transactions, querying account balances, and interacting with smart contracts directly through popular browser wallets.
+- **Wallet Provider submodule - `tatum.walletProvider.*`**: This submodule enables seamless interaction with external wallets like Metamask or Phantom within the browser. The Wallet Provider submodule allows the SDK to communicate with various wallet providers, streamlining the process of signing transactions, querying account balances, and interacting with smart contracts directly through popular browser wallets.
 
-* **Rate Exchange submodule - `tatum.rates.*`**: This submodule enables allows you to easily obtain exchange rates for fiat/crypto.
+- **Rate Exchange submodule - `tatum.rates.*`**: This submodule enables allows you to easily obtain exchange rates for fiat/crypto.
+
+- **Fee submodule - `tatum.fee.*`**: This submodule allows you to easily obtain recommended fee/gas for a blockchain
+
+- **Token submodule - `tatum.token.*`**: This submodule enables you to interact with fungible tokens on a specified blockchain. It facilitates the tracking of fungible token balances for a wallet address and allows the retrieval of details or transactions for a specific token. Additionally, this submodule can be used to create a new fungible token.
 
 By dividing the library into these submodules, TatumSDK offers an organized, easy-to-use interface that makes interacting with Ethereum and other blockchains a breeze. Both beginners and advanced developers can benefit from the streamlined architecture, enabling them to focus on building powerful blockchain applications.
 
@@ -209,6 +243,7 @@ Older versions of the Tatum SDK has been moved to long living branches [`Tatum S
 ## Contributing
 
 Contributions to the Tatum SDK are welcome. Please ensure that you have tested your changes with a local client and have added unit test coverage for your code.
+
 ### Bugs and feature requests
 
 Have a bug or a feature request? Please first read the issue guidelines and search for existing and closed issues. If your problem or idea is not addressed yet, please open a [new issue](https://github.com/tatumio/tatum-js/issues/new/choose).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumcom/js",
-  "version": "1.4.24",
+  "version": "1.4.25",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/dto/Currency.ts
+++ b/src/dto/Currency.ts
@@ -1,0 +1,27 @@
+import { Network } from './Network'
+
+export enum Currency {
+  ETH = 'ETH',
+  BTC = 'BTC',
+  DOGE = 'DOGE',
+  LTC = 'LTC',
+}
+
+export function networkToCurrency(network: Network): Currency {
+  switch (network) {
+    case Network.ETHEREUM:
+    case Network.ETHEREUM_SEPOLIA:
+      return Currency.ETH
+    case Network.BITCOIN:
+    case Network.BITCOIN_TESTNET:
+      return Currency.BTC
+    case Network.DOGECOIN:
+    case Network.DOGECOIN_TESTNET:
+      return Currency.DOGE
+    case Network.LITECOIN:
+    case Network.LITECOIN_TESTNET:
+      return Currency.LTC
+    default:
+      throw new Error(`Unsupported network ${network}`)
+  }
+}

--- a/src/dto/rpc/index.ts
+++ b/src/dto/rpc/index.ts
@@ -1,44 +1,5 @@
-import { EvmBasedRpcSuite } from './EvmBasedRpcSuite'
-import { SolanaRpcSuite } from './SolanaRpcSuite'
-import { TronRpcSuite } from './TronRpcSuite'
-import { UtxoBasedRpcSuite } from './UtxoBasedRpcSuite'
-import { XrpRpcSuite } from './XrpRpcSuite'
-
 export * from './EvmBasedRpcSuite'
 export * from './SolanaRpcSuite'
 export * from './TronRpcSuite'
 export * from './UtxoBasedRpcSuite'
 export * from './XrpRpcSuite'
-
-// EVM chains
-export type Ethereum = EvmBasedRpcSuite
-export type ArbitrumNova = EvmBasedRpcSuite
-export type ArbitrumOne = EvmBasedRpcSuite
-export type Aurora = EvmBasedRpcSuite
-export type AvalancheC = EvmBasedRpcSuite
-export type BinanceSmartChain = EvmBasedRpcSuite
-export type Celo = EvmBasedRpcSuite
-export type Cronos = EvmBasedRpcSuite
-export type EthereumClassic = EvmBasedRpcSuite
-export type Fantom = EvmBasedRpcSuite
-export type Gnosis = EvmBasedRpcSuite
-export type HarmonyOne = EvmBasedRpcSuite
-export type Klaytn = EvmBasedRpcSuite
-export type Kucoin = EvmBasedRpcSuite
-export type Oasis = EvmBasedRpcSuite
-export type Optimism = EvmBasedRpcSuite
-export type Palm = EvmBasedRpcSuite
-export type Polygon = EvmBasedRpcSuite
-export type Vechain = EvmBasedRpcSuite
-export type Xdc = EvmBasedRpcSuite
-
-// UTXO chains
-export type Bitcoin = UtxoBasedRpcSuite
-export type Litecoin = UtxoBasedRpcSuite
-export type Dogecoin = UtxoBasedRpcSuite
-export type BitcoinCash = UtxoBasedRpcSuite
-
-// other chains
-export type Xrp = XrpRpcSuite
-export type Solana = SolanaRpcSuite
-export type Tron = TronRpcSuite

--- a/src/dto/rpc/index.ts
+++ b/src/dto/rpc/index.ts
@@ -1,14 +1,14 @@
 import { EvmBasedRpcSuite } from './EvmBasedRpcSuite'
 import { SolanaRpcSuite } from './SolanaRpcSuite'
+import { TronRpcSuite } from './TronRpcSuite'
 import { UtxoBasedRpcSuite } from './UtxoBasedRpcSuite'
 import { XrpRpcSuite } from './XrpRpcSuite'
-import {TronRpcSuite} from "./TronRpcSuite";
 
 export * from './EvmBasedRpcSuite'
 export * from './SolanaRpcSuite'
+export * from './TronRpcSuite'
 export * from './UtxoBasedRpcSuite'
 export * from './XrpRpcSuite'
-export * from './TronRpcSuite'
 
 // EVM chains
 export type Ethereum = EvmBasedRpcSuite
@@ -31,7 +31,6 @@ export type Palm = EvmBasedRpcSuite
 export type Polygon = EvmBasedRpcSuite
 export type Vechain = EvmBasedRpcSuite
 export type Xdc = EvmBasedRpcSuite
-export type Tron = TronRpcSuite
 
 // UTXO chains
 export type Bitcoin = UtxoBasedRpcSuite
@@ -42,3 +41,4 @@ export type BitcoinCash = UtxoBasedRpcSuite
 // other chains
 export type Xrp = XrpRpcSuite
 export type Solana = SolanaRpcSuite
+export type Tron = TronRpcSuite

--- a/src/e2e/e2e.util.ts
+++ b/src/e2e/e2e.util.ts
@@ -1,10 +1,13 @@
 import {
   AddressBasedNotification,
   AddressBasedNotificationDetail,
+  BaseTatumSdk,
   BlockBasedNotification,
-  BlockBasedNotificationDetail, ContractBasedNotification, ContractBasedNotificationDetail,
+  BlockBasedNotificationDetail,
+  ContractBasedNotification,
+  ContractBasedNotificationDetail,
+  Ethereum,
   Network,
-  TatumSDK,
 } from '../service'
 import { ResponseDto } from '../util'
 
@@ -64,7 +67,7 @@ export const e2eUtil = {
       }
     },
     testAddressBasedSubscription: async (
-      tatum: TatumSDK<unknown>,
+      tatum: BaseTatumSdk,
       address: string,
       func: (
         addressBasedNotificationDetail: AddressBasedNotificationDetail,
@@ -78,7 +81,7 @@ export const e2eUtil = {
       console.log(data)
       console.log(error)
 
-      if(error){
+      if (error) {
         throw new Error(error.message.join(','))
       }
 
@@ -89,7 +92,7 @@ export const e2eUtil = {
       expect(url).toBeDefined()
     },
     testContractBasedSubscription: async (
-      tatum: TatumSDK<unknown>,
+      tatum: Ethereum,
       contractAddress: string,
       func: (
         contractBasedNotificationDetail: ContractBasedNotificationDetail,
@@ -106,7 +109,7 @@ export const e2eUtil = {
       console.log(data)
       console.log(error)
 
-      if(error){
+      if (error) {
         throw new Error(error.message.join(','))
       }
 
@@ -117,7 +120,7 @@ export const e2eUtil = {
       expect(url).toBeDefined()
     },
     testBlockBasedSubscription: async (
-      tatum: TatumSDK<unknown>,
+      tatum: Ethereum,
       func: (
         blockBasedNotificationDetail: BlockBasedNotificationDetail,
       ) => Promise<ResponseDto<BlockBasedNotification>>,

--- a/src/e2e/tatum.address.spec.ts
+++ b/src/e2e/tatum.address.spec.ts
@@ -1,16 +1,16 @@
-import { Bitcoin, Dogecoin, Ethereum, Litecoin, Network } from '../dto'
-import { TatumSDK } from '../service'
+import { Network } from '../dto'
+import { BaseTatumSdk, Bitcoin, Dogecoin, Ethereum, Litecoin, Solana, TatumSDK, Xrp } from '../service'
 import { Status } from '../util'
 
 describe('Address', () => {
   describe('Address Balance', () => {
     describe('getBalance EVM', () => {
-      let tatumSDK: TatumSDK<Ethereum>
+      let client: Ethereum
       beforeAll(async () => {
-        tatumSDK = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM_SEPOLIA, verbose: true })
+        client = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM_SEPOLIA, verbose: true })
       })
       it('should get balance with native assets only', async () => {
-        const { data } = await tatumSDK.address.getBalance({
+        const { data } = await client.address.getBalance({
           addresses: ['0x514D547c8aC8ccBEc29b5144810454BD7d3625CA'],
         })
         expect(data).toHaveLength(1)
@@ -24,8 +24,11 @@ describe('Address', () => {
       })
 
       it('should get balance with native assets only for 2 addresses', async () => {
-        const { data } = await tatumSDK.address.getBalance({
-          addresses: ['0x514D547c8aC8ccBEc29b5144810454BD7d3625CA', '0x514D547c8aC8ccBEc29b5144810454BD7d3625CA'],
+        const { data } = await client.address.getBalance({
+          addresses: [
+            '0x514D547c8aC8ccBEc29b5144810454BD7d3625CA',
+            '0x514D547c8aC8ccBEc29b5144810454BD7d3625CA',
+          ],
         })
         expect(data).toHaveLength(2)
         expect(data[0]).toStrictEqual({
@@ -45,7 +48,7 @@ describe('Address', () => {
       })
 
       it('should get balance with native, erc20 and erc721 assets', async () => {
-        const { data } = await tatumSDK.address.getBalance({
+        const { data } = await client.address.getBalance({
           addresses: ['0x514D547c8aC8CCBEc29B5144810454BD7D3625cB'],
         })
         expect(data).toHaveLength(3)
@@ -75,12 +78,12 @@ describe('Address', () => {
     })
 
     describe('getBalance SOL', () => {
-      let tatumSDK: TatumSDK<unknown>
+      let client: Solana
       beforeAll(async () => {
-        tatumSDK = await TatumSDK.init({ network: Network.SOLANA_DEVNET, verbose: true })
+        client = await TatumSDK.init<Solana>({ network: Network.SOLANA_DEVNET, verbose: true })
       })
       it('should get balance with native assets only', async () => {
-        const { data } = await tatumSDK.address.getBalance({
+        const { data } = await client.address.getBalance({
           addresses: ['5RMd4Uy6LVyJqMqNPYmerZdzBPCtyq964WBfhPdT2SWi'],
         })
         expect(data).toHaveLength(1)
@@ -95,12 +98,12 @@ describe('Address', () => {
     })
 
     describe('getBalance BTC', () => {
-      let tatumSDK: TatumSDK<Bitcoin>
+      let client: Bitcoin
       beforeAll(async () => {
-        tatumSDK = await TatumSDK.init<Bitcoin>({ network: Network.BITCOIN_TESTNET, verbose: true })
+        client = await TatumSDK.init<Bitcoin>({ network: Network.BITCOIN_TESTNET, verbose: true })
       })
       it('should get balance with native assets only', async () => {
-        const { data } = await tatumSDK.address.getBalance({
+        const { data } = await client.address.getBalance({
           addresses: ['tb1qrd9jz8ksy3qqm400vt296udlvk89z96p443mv0'],
         })
         expect(data).toHaveLength(1)
@@ -115,12 +118,12 @@ describe('Address', () => {
     })
 
     describe('getBalance DOGE', () => {
-      let tatumSDK: TatumSDK<Dogecoin>
+      let client: Dogecoin
       beforeAll(async () => {
-        tatumSDK = await TatumSDK.init<Dogecoin>({ network: Network.DOGECOIN_TESTNET, verbose: true })
+        client = await TatumSDK.init<Dogecoin>({ network: Network.DOGECOIN_TESTNET, verbose: true })
       })
       it('should get balance with native assets only', async () => {
-        const { data } = await tatumSDK.address.getBalance({
+        const { data } = await client.address.getBalance({
           addresses: ['nqNmVv1PCPFbNQLBMbeKhW4YrswqEgpVsr'],
         })
         expect(data).toHaveLength(1)
@@ -135,12 +138,12 @@ describe('Address', () => {
     })
 
     describe('getBalance LTC', () => {
-      let tatumSDK: TatumSDK<Litecoin>
+      let client: Litecoin
       beforeAll(async () => {
-        tatumSDK = await TatumSDK.init<Litecoin>({ network: Network.LITECOIN_TESTNET, verbose: true })
+        client = await TatumSDK.init<Litecoin>({ network: Network.LITECOIN_TESTNET, verbose: true })
       })
       it('should get balance with native assets only', async () => {
-        const { data } = await tatumSDK.address.getBalance({
+        const { data } = await client.address.getBalance({
           addresses: ['n22dLZeTMRCUpaLMdgDcQzUXJJnfKcsnS3'],
         })
         expect(data).toHaveLength(1)
@@ -155,7 +158,7 @@ describe('Address', () => {
     })
 
     describe('getBalance CARDANO', () => {
-      let tatumSDK: TatumSDK<unknown>
+      let tatumSDK: BaseTatumSdk
       beforeAll(async () => {
         tatumSDK = await TatumSDK.init({ network: Network.CARDANO_PREPROD, verbose: true })
       })
@@ -175,12 +178,12 @@ describe('Address', () => {
     })
 
     describe('getBalance XRP', () => {
-      let tatumSDK: TatumSDK<unknown>
+      let client: Xrp
       beforeAll(async () => {
-        tatumSDK = await TatumSDK.init({ network: Network.XRP_TESTNET, verbose: true })
+        client = await TatumSDK.init({ network: Network.XRP_TESTNET, verbose: true })
       })
       it('should get balance with native assets only', async () => {
-        const response = await tatumSDK.address.getBalance({
+        const response = await client.address.getBalance({
           addresses: ['rK2MUqCRuodSxyYjfregVuJyMgbVXgeyAG'],
         })
         expect(response.data).toHaveLength(1)
@@ -197,13 +200,13 @@ describe('Address', () => {
 
   describe('getTransactions', () => {
     describe('getTransactions EVM', () => {
-      let tatum: TatumSDK<Ethereum>
+      let client: Ethereum
       beforeAll(async () => {
-        tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM_SEPOLIA, verbose: true })
+        client = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM_SEPOLIA, verbose: true })
       })
 
       it('should get transactions - native only', async () => {
-        const txs = await tatum.address.getTransactions({
+        const txs = await client.address.getTransactions({
           address: '0x514D547c8aC8ccBEc29b5144810454BD7d3625CA',
         })
         expect(txs.status === Status.SUCCESS)
@@ -224,7 +227,7 @@ describe('Address', () => {
       })
 
       it('should get transactions - tokens only', async () => {
-        const txs = await tatum.address.getTransactions({
+        const txs = await client.address.getTransactions({
           address: '0x514D547c8aC8CCBEc29B5144810454BD7D3625cB',
         })
         expect(txs.status === Status.SUCCESS)
@@ -258,7 +261,7 @@ describe('Address', () => {
         })
       })
       it('should get transactions - NFT tokens only', async () => {
-        const txs = await tatum.address.getTransactions({
+        const txs = await client.address.getTransactions({
           address: '0x514D547c8aC8CCBEc29B5144810454BD7D3625cB',
           transactionTypes: ['nft'],
         })
@@ -280,11 +283,11 @@ describe('Address', () => {
         })
       })
       it('should get transactions - pagination', async () => {
-        const page1 = await tatum.address.getTransactions({
+        const page1 = await client.address.getTransactions({
           address: '0x514D547c8aC8CCBEc29B5144810454BD7D3625cB',
           pageSize: 1,
         })
-        const page2 = await tatum.address.getTransactions({
+        const page2 = await client.address.getTransactions({
           address: '0x514D547c8aC8CCBEc29B5144810454BD7D3625cB',
           pageSize: 1,
           page: 1,
@@ -297,13 +300,13 @@ describe('Address', () => {
       })
     })
     describe('getTransactions BITCOIN', () => {
-      let tatum: TatumSDK<Bitcoin>
+      let client: Bitcoin
       beforeAll(async () => {
-        tatum = await TatumSDK.init<Bitcoin>({ network: Network.BITCOIN_TESTNET, verbose: true })
+        client = await TatumSDK.init<Bitcoin>({ network: Network.BITCOIN_TESTNET, verbose: true })
       })
 
       it('should get transactions', async () => {
-        const txs = await tatum.address.getTransactions({
+        const txs = await client.address.getTransactions({
           address: 'tb1qrd9jz8ksy3qqm400vt296udlvk89z96p443mv0',
         })
         expect(txs.status === Status.SUCCESS)
@@ -338,13 +341,13 @@ describe('Address', () => {
       })
     })
     describe('getTransactions DOGECOIN', () => {
-      let tatum: TatumSDK<Dogecoin>
+      let client: Dogecoin
       beforeAll(async () => {
-        tatum = await TatumSDK.init<Dogecoin>({ network: Network.DOGECOIN_TESTNET, verbose: true })
+        client = await TatumSDK.init<Dogecoin>({ network: Network.DOGECOIN_TESTNET, verbose: true })
       })
 
       it('should get transactions', async () => {
-        const txs = await tatum.address.getTransactions({
+        const txs = await client.address.getTransactions({
           address: 'nqNmVv1PCPFbNQLBMbeKhW4YrswqEgpVsr',
           pageSize: 3,
         })
@@ -380,13 +383,13 @@ describe('Address', () => {
       })
     })
     describe('getTransactions LITECOIN', () => {
-      let tatum: TatumSDK<Litecoin>
+      let client: Litecoin
       beforeAll(async () => {
-        tatum = await TatumSDK.init<Litecoin>({ network: Network.LITECOIN_TESTNET, verbose: true })
+        client = await TatumSDK.init<Litecoin>({ network: Network.LITECOIN_TESTNET, verbose: true })
       })
 
       it('should get transactions', async () => {
-        const txs = await tatum.address.getTransactions({
+        const txs = await client.address.getTransactions({
           address: 'n22dLZeTMRCUpaLMdgDcQzUXJJnfKcsnS3',
         })
         expect(txs.status === Status.SUCCESS)

--- a/src/e2e/tatum.address.spec.ts
+++ b/src/e2e/tatum.address.spec.ts
@@ -13,7 +13,7 @@ describe('Address', () => {
         const { data } = await client.address.getBalance({
           addresses: ['0x514D547c8aC8ccBEc29b5144810454BD7d3625CA'],
         })
-        expect(data).toHaveLength(1)
+        expect(data).toHaveLength(2)
         expect(data[0]).toStrictEqual({
           asset: 'ETH',
           decimals: 18,
@@ -30,7 +30,7 @@ describe('Address', () => {
             '0x514D547c8aC8ccBEc29b5144810454BD7d3625CA',
           ],
         })
-        expect(data).toHaveLength(2)
+        expect(data).toHaveLength(3)
         expect(data[0]).toStrictEqual({
           asset: 'ETH',
           address: '0x514D547c8aC8ccBEc29b5144810454BD7d3625CA',
@@ -208,6 +208,7 @@ describe('Address', () => {
       it('should get transactions - native only', async () => {
         const txs = await client.address.getTransactions({
           address: '0x514D547c8aC8ccBEc29b5144810454BD7d3625CA',
+          transactionTypes: ['native'],
         })
         expect(txs.status === Status.SUCCESS)
         // at least one transaction

--- a/src/e2e/tatum.fee.spec.ts
+++ b/src/e2e/tatum.fee.spec.ts
@@ -1,5 +1,5 @@
-import { Bitcoin, Ethereum } from '../dto'
 import { ApiVersion, Network, TatumSDK } from '../service'
+import { Bitcoin, Ethereum } from '../service/tatum'
 
 describe('Fee', () => {
   it('should return fee for eth testnet', async () => {
@@ -11,8 +11,8 @@ describe('Fee', () => {
       version: ApiVersion.V1,
     })
 
-    const result: any = await tatum.fee.getCurrentFee()
-    expect(result.basedOnBlockNumber).toBeDefined()
+    const result = await tatum.fee.getCurrentFee()
+    expect(result.gasPrice.fast).toBeDefined()
   })
 
   it('should return fee for btc testnet', async () => {
@@ -24,7 +24,7 @@ describe('Fee', () => {
       version: ApiVersion.V1,
     })
 
-    const result: any = await tatum.fee.getCurrentFee()
-    expect(result.basedOnBlockNumber).toBeDefined()
+    const result = await tatum.fee.getCurrentFee()
+    expect(result.fast).toBeDefined()
   })
 })

--- a/src/e2e/tatum.fee.spec.ts
+++ b/src/e2e/tatum.fee.spec.ts
@@ -1,0 +1,30 @@
+import { Bitcoin, Ethereum } from '../dto'
+import { ApiVersion, Network, TatumSDK } from '../service'
+
+describe('Fee', () => {
+  it('should return fee for eth testnet', async () => {
+    const tatum = await TatumSDK.init<Ethereum>({
+      network: Network.ETHEREUM_SEPOLIA,
+      verbose: true,
+      retryDelay: 1000,
+      retryCount: 2,
+      version: ApiVersion.V1,
+    })
+
+    const result: any = await tatum.fee.getCurrentFee()
+    expect(result.basedOnBlockNumber).toBeDefined()
+  })
+
+  it('should return fee for btc testnet', async () => {
+    const tatum = await TatumSDK.init<Bitcoin>({
+      network: Network.BITCOIN_TESTNET,
+      verbose: true,
+      retryDelay: 1000,
+      retryCount: 2,
+      version: ApiVersion.V1,
+    })
+
+    const result: any = await tatum.fee.getCurrentFee()
+    expect(result.basedOnBlockNumber).toBeDefined()
+  })
+})

--- a/src/e2e/tatum.nft.spec.ts
+++ b/src/e2e/tatum.nft.spec.ts
@@ -85,9 +85,10 @@ describe('Tatum NFT', () => {
     it('should get NFT transactions for a specific NFT token on the address', async () => {
       const { data: txs } = await client.nft.getAllNftTransactionsByAddress({
         addresses: ['0x53e8577c4347c365e4e0da5b57a589cb6f2ab849'],
+        tokenAddress: '0x211500d1960bdb7ba3390347ffd8ad486b897a18',
       })
-      expect(txs).toHaveLength(3)
-      expect(txs[1]).toStrictEqual({
+      expect(txs).toHaveLength(1)
+      expect(txs[0]).toStrictEqual({
         address: '0x53e8577c4347c365e4e0da5b57a589cb6f2ab849',
         amount: '1',
         blockNumber: 3306734,

--- a/src/e2e/tatum.nft.spec.ts
+++ b/src/e2e/tatum.nft.spec.ts
@@ -1,10 +1,9 @@
-import { Ethereum } from '../dto'
-import { Network, TatumSDK } from '../service'
+import { Ethereum, Network, TatumSDK } from '../service'
 
 describe('Tatum NFT', () => {
-  let tatum: TatumSDK<Ethereum>
+  let client: Ethereum
   beforeAll(async () => {
-    tatum = await TatumSDK.init<Ethereum>({
+    client = await TatumSDK.init<Ethereum>({
       network: Network.ETHEREUM_SEPOLIA,
       verbose: true,
       retryDelay: 1000,
@@ -13,7 +12,7 @@ describe('Tatum NFT', () => {
   })
   describe('NFT balances', () => {
     it('should get NFT balances', async () => {
-      const { data: balance } = await tatum.nft.getBalance({
+      const { data: balance } = await client.nft.getBalance({
         addresses: ['0x53e8577c4347c365e4e0da5b57a589cb6f2ab849'],
       })
       expect(balance).toBeDefined()
@@ -49,7 +48,7 @@ describe('Tatum NFT', () => {
 
   describe('NFT transactions', () => {
     it('should get NFT transactions for a specific NFT token', async () => {
-      const { data: txs } = await tatum.nft.getAllNftTransactions({
+      const { data: txs } = await client.nft.getAllNftTransactions({
         tokenId: '1395688000000000',
         tokenAddress: '0x211500d1960bdb7ba3390347ffd8ad486b897a18',
       })
@@ -84,7 +83,7 @@ describe('Tatum NFT', () => {
       })
     })
     it('should get NFT transactions for a specific NFT token on the address', async () => {
-      const { data: txs } = await tatum.nft.getAllNftTransactionsByAddress({
+      const { data: txs } = await client.nft.getAllNftTransactionsByAddress({
         addresses: ['0x53e8577c4347c365e4e0da5b57a589cb6f2ab849'],
       })
       expect(txs).toHaveLength(3)
@@ -107,7 +106,7 @@ describe('Tatum NFT', () => {
 
   describe('NFT owners', () => {
     it('should get NFT owners for a specific NFT token', async () => {
-      const { data: owner } = await tatum.nft.getNftOwner({
+      const { data: owner } = await client.nft.getNftOwner({
         tokenAddress: '0xf31a94466dd524a9e711d5599c470b1f65b3b4d8',
         tokenId: '1',
       })
@@ -116,7 +115,7 @@ describe('Tatum NFT', () => {
     })
 
     it('should not get NFT owners for a specific NFT token - no such token', async () => {
-      const { data: owner } = await tatum.nft.getNftOwner({
+      const { data: owner } = await client.nft.getNftOwner({
         tokenAddress: '0xf31a94466dd524a9e711d5599c470b1f65b3b4d8',
         tokenId: '10',
       })
@@ -125,7 +124,7 @@ describe('Tatum NFT', () => {
 
     it('check if NFT is owned by a specific address', async () => {
       expect(
-        await tatum.nft.checkNftOwner({
+        await client.nft.checkNftOwner({
           tokenAddress: '0xf31a94466dd524a9e711d5599c470b1f65b3b4d8',
           tokenId: '1',
           owner: '0x53e8577c4347c365e4e0da5b57a589cb6f2ab849',
@@ -135,7 +134,7 @@ describe('Tatum NFT', () => {
 
     it('check if NFT is owned by a specific address - not the owner', async () => {
       expect(
-        await tatum.nft.checkNftOwner({
+        await client.nft.checkNftOwner({
           tokenAddress: '0xf31a94466dd524a9e711d5599c470b1f65b3b4d8',
           tokenId: '10',
           owner: '0x53e8577c4347c365e4e0da5b57a589cb6f2ab849',
@@ -146,7 +145,7 @@ describe('Tatum NFT', () => {
 
   describe('NFT collections', () => {
     it('should get small collection', async function () {
-      const { data: collection } = await tatum.nft.getNftsInCollection({
+      const { data: collection } = await client.nft.getNftsInCollection({
         collectionAddress: '0xf31a94466dd524a9e711d5599c470b1f65b3b4d8',
       })
       expect(collection).toHaveLength(1)
@@ -161,7 +160,7 @@ describe('Tatum NFT', () => {
     })
 
     it('should get small collection without metadata', async function () {
-      const { data: collection } = await tatum.nft.getNftsInCollection({
+      const { data: collection } = await client.nft.getNftsInCollection({
         collectionAddress: '0xf31a94466dd524a9e711d5599c470b1f65b3b4d8',
         excludeMetadata: true,
       })
@@ -176,13 +175,13 @@ describe('Tatum NFT', () => {
     })
 
     it('should get big collection with pagination', async function () {
-      const { data: collectionPage1 } = await tatum.nft.getNftsInCollection({
+      const { data: collectionPage1 } = await client.nft.getNftsInCollection({
         collectionAddress: '0x55d5f0a37488d6734c33c6c3c6a2234a75f2e521',
         excludeMetadata: true,
         pageSize: 10,
       })
       expect(collectionPage1).toHaveLength(10)
-      const { data: collectionPage2 } = await tatum.nft.getNftsInCollection({
+      const { data: collectionPage2 } = await client.nft.getNftsInCollection({
         collectionAddress: '0x55d5f0a37488d6734c33c6c3c6a2234a75f2e521',
         excludeMetadata: true,
         pageSize: 10,
@@ -195,7 +194,7 @@ describe('Tatum NFT', () => {
 
   describe('NFT metadata', () => {
     it('should get NFT Metadata for NFT', async function () {
-      const { data: metadata } = await tatum.nft.getNftMetadata({
+      const { data: metadata } = await client.nft.getNftMetadata({
         tokenAddress: '0x55d5f0a37488d6734c33c6c3c6a2234a75f2e521',
         tokenId: '1',
       })
@@ -212,19 +211,19 @@ describe('Tatum NFT', () => {
 
   describe.skip('Create collections', () => {
     it('should create NFT ERC721 collection', async () => {
-      const result = await tatum.nft.createNftCollection({
+      const result = await client.nft.createNftCollection({
         name: 'Test Collection',
         symbol: 'TST',
         owner: '0x53e8577c4347c365e4e0da5b57a589cb6f2ab849',
       })
-      expect(result.data).toStrictEqual({txId: expect.any(String)})
+      expect(result.data).toStrictEqual({ txId: expect.any(String) })
     })
 
     it('should create NFT ERC1155 collection', async () => {
-      const result = await tatum.nft.createMultiTokenNftCollection({
+      const result = await client.nft.createMultiTokenNftCollection({
         owner: '0x53e8577c4347c365e4e0da5b57a589cb6f2ab849',
       })
-      expect(result.data).toStrictEqual({txId: expect.any(String)})
+      expect(result.data).toStrictEqual({ txId: expect.any(String) })
     })
   })
 })

--- a/src/e2e/tatum.notification.spec.ts
+++ b/src/e2e/tatum.notification.spec.ts
@@ -1,23 +1,30 @@
 import { Network } from '../dto'
-import { NotificationSubscription, TatumSDK } from '../service'
+import { Ethereum, NotificationSubscription, TatumSDK } from '../service'
 import { Status } from '../util'
 import {
   AddressEventNetworks,
   ContractAddressLogEventNetworks,
   FailedTxPerBlockNetworks,
-  FungibleTxNetworks, IncomingNativeTxNetworks,
+  FungibleTxNetworks,
+  IncomingNativeTxNetworks,
   InternalTxNetworks,
   MultitokenNetworks,
   NftNetworks,
-  OutgoingFailedNetworks, OutgoingNativeTxNetworks,
+  OutgoingFailedNetworks,
+  OutgoingNativeTxNetworks,
   PaidFeeNetworks,
-  TestConst
+  TestConst,
 } from './e2e.constant'
 import { e2eUtil } from './e2e.util'
 
 describe('notification', () => {
   beforeAll(async () => {
-    const tatum = await TatumSDK.init({network: Network.ETHEREUM, verbose: true, retryCount: 10, retryDelay: 5000})
+    const tatum = await TatumSDK.init<Ethereum>({
+      network: Network.ETHEREUM,
+      verbose: true,
+      retryCount: 10,
+      retryDelay: 5000,
+    })
     const notifications = await tatum.notification.getAll()
 
     for (const notification of notifications.data as NotificationSubscription[]) {
@@ -28,7 +35,12 @@ describe('notification', () => {
     describe('IP auth', () => {
       describe('Address Event', () => {
         it.each(Object.values(AddressEventNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -39,7 +51,12 @@ describe('notification', () => {
 
       describe('Incoming Native Tx', () => {
         it.each(Object.values(IncomingNativeTxNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -50,7 +67,12 @@ describe('notification', () => {
 
       describe('Outgoing Native Tx', () => {
         it.each(Object.values(OutgoingNativeTxNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -61,7 +83,12 @@ describe('notification', () => {
 
       describe('Outgoing Failed Tx', () => {
         it.each(Object.values(OutgoingFailedNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -72,7 +99,12 @@ describe('notification', () => {
 
       describe('Paid Fee', () => {
         it.each(Object.values(PaidFeeNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -83,7 +115,12 @@ describe('notification', () => {
 
       describe('Incoming Internal Tx', () => {
         it.each(Object.values(InternalTxNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -94,7 +131,12 @@ describe('notification', () => {
 
       describe('Outgoing Internal Tx', () => {
         it.each(Object.values(InternalTxNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -105,7 +147,12 @@ describe('notification', () => {
 
       describe('Incoming Fungible Tx', () => {
         it.each(Object.values(FungibleTxNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -116,7 +163,12 @@ describe('notification', () => {
 
       describe('Outgoing Fungible Tx', () => {
         it.each(Object.values(FungibleTxNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -127,7 +179,12 @@ describe('notification', () => {
 
       describe('Incoming Nft Tx', () => {
         it.each(Object.values(NftNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -136,10 +193,14 @@ describe('notification', () => {
         })
       })
 
-
       describe('Outgoing Nft Tx', () => {
         it.each(Object.values(NftNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -150,7 +211,12 @@ describe('notification', () => {
 
       describe('Incoming Multitoken Tx', () => {
         it.each(Object.values(MultitokenNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -161,7 +227,12 @@ describe('notification', () => {
 
       describe('Outgoing Multitoken Tx', () => {
         it.each(Object.values(MultitokenNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testAddressBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -172,7 +243,12 @@ describe('notification', () => {
 
       describe('Failed Txs Per Block', () => {
         it.each(Object.values(FailedTxPerBlockNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testBlockBasedSubscription(
             tatum,
             tatum.notification.subscribe.failedTxsPerBlock,
@@ -182,7 +258,12 @@ describe('notification', () => {
 
       describe('Contract Address Log Event', () => {
         it.each(Object.values(ContractAddressLogEventNetworks))('OK %s', async (network: Network) => {
-          const tatum = await TatumSDK.init({ network, verbose: true, retryCount: 10, retryDelay: 5000 })
+          const tatum = await TatumSDK.init<Ethereum>({
+            network,
+            verbose: true,
+            retryCount: 10,
+            retryDelay: 5000,
+          })
           await e2eUtil.subscriptions.testContractBasedSubscription(
             tatum,
             e2eUtil.subscriptions.getAddress(network),
@@ -193,7 +274,12 @@ describe('notification', () => {
     })
 
     it('NOK - existing subscription ', async () => {
-      const tatum = await TatumSDK.init({ network: Network.ETHEREUM, verbose: true, retryCount: 10, retryDelay: 5000 })
+      const tatum = await TatumSDK.init<Ethereum>({
+        network: Network.ETHEREUM,
+        verbose: true,
+        retryCount: 10,
+        retryDelay: 5000,
+      })
       await tatum.notification.subscribe.addressEvent({
         url: 'https://tatum.com',
         address: TestConst.EXISTING_SUBSCRIPTION_ETH_ADDRESS,
@@ -212,7 +298,12 @@ describe('notification', () => {
     })
 
     it('NOK - invalid address', async () => {
-      const tatum = await TatumSDK.init({ network: Network.ETHEREUM, verbose: true, retryCount: 10, retryDelay: 5000 })
+      const tatum = await TatumSDK.init<Ethereum>({
+        network: Network.ETHEREUM,
+        verbose: true,
+        retryCount: 10,
+        retryDelay: 5000,
+      })
 
       const { status, error } = await tatum.notification.subscribe.addressEvent({
         url: 'https://tatum.io',
@@ -228,7 +319,12 @@ describe('notification', () => {
 
   describe('deleteSubscription', () => {
     it('OK', async () => {
-      const tatum = await TatumSDK.init({ network: Network.ETHEREUM_SEPOLIA, verbose: true, retryCount: 10, retryDelay: 5000 })
+      const tatum = await TatumSDK.init<Ethereum>({
+        network: Network.ETHEREUM_SEPOLIA,
+        verbose: true,
+        retryCount: 10,
+        retryDelay: 5000,
+      })
       const address = e2eUtil.subscriptions.getAddress(Network.ETHEREUM_SEPOLIA)
       const { data: subscribeData } = await tatum.notification.subscribe.addressEvent({
         url: 'https://tatum.io',
@@ -244,7 +340,12 @@ describe('notification', () => {
     })
 
     it('NOK - invalid subscription', async () => {
-      const tatum = await TatumSDK.init({ network: Network.ETHEREUM_SEPOLIA, verbose: true, retryCount: 10, retryDelay: 5000 })
+      const tatum = await TatumSDK.init<Ethereum>({
+        network: Network.ETHEREUM_SEPOLIA,
+        verbose: true,
+        retryCount: 10,
+        retryDelay: 5000,
+      })
       const { data, status, error } = await tatum.notification.unsubscribe('invalid-subscription-id')
       expect(data).toEqual(null)
       expect(status).toEqual(Status.ERROR)
@@ -255,7 +356,12 @@ describe('notification', () => {
   })
 
   it('getAll', async () => {
-    const tatum = await TatumSDK.init({ network: Network.ETHEREUM, verbose: true, retryCount: 10, retryDelay: 5000 })
+    const tatum = await TatumSDK.init<Ethereum>({
+      network: Network.ETHEREUM,
+      verbose: true,
+      retryCount: 10,
+      retryDelay: 5000,
+    })
     const { data, error } = await tatum.notification.getAll()
     console.log(new Date().toISOString(), error)
     expect(data).not.toHaveLength(0)
@@ -269,7 +375,12 @@ describe('notification', () => {
 
   // TODO pipeline dont work with this test - IP auth
   it.skip('getAllExecutedWebhooks', async () => {
-    const tatum = await TatumSDK.init({ network: Network.ETHEREUM_SEPOLIA, verbose: true, retryCount: 10, retryDelay: 5000 })
+    const tatum = await TatumSDK.init<Ethereum>({
+      network: Network.ETHEREUM_SEPOLIA,
+      verbose: true,
+      retryCount: 10,
+      retryDelay: 5000,
+    })
     const { data } = await tatum.notification.getAllExecutedWebhooks()
     expect(data[0].type).toBeDefined()
     expect(data[0].id).toBeDefined()

--- a/src/e2e/tatum.rates.spec.ts
+++ b/src/e2e/tatum.rates.spec.ts
@@ -1,8 +1,7 @@
-import { ApiVersion, Network, TatumSDK } from "../service";
-import { Ethereum } from "../dto";
+import { ApiVersion, Ethereum, Network, TatumSDK } from '../service'
 
-describe("Rates", () => {
-  let tatum: TatumSDK<Ethereum>
+describe('Rates', () => {
+  let tatum: Ethereum
   beforeAll(async () => {
     tatum = await TatumSDK.init<Ethereum>({
       network: Network.ETHEREUM_SEPOLIA,
@@ -12,12 +11,15 @@ describe("Rates", () => {
       version: ApiVersion.V2,
     })
   })
-  it("get ETH/EUR", async () => {
-    const res = await tatum.rates.getCurrentRate("BTC","EUR");
-    expect(res.data.value).toBeDefined();
-  });
-  it("get batch", async () => {
-    const res = await tatum.rates.getCurrentRateBatch([{currency: "BTC", basePair: "EUR"}, {currency: "ETH", basePair: "EUR"}]);
-    expect(res.data[1].value).toBeDefined();
-  });
-});
+  it('get ETH/EUR', async () => {
+    const res = await tatum.rates.getCurrentRate('BTC', 'EUR')
+    expect(res.data.value).toBeDefined()
+  })
+  it('get batch', async () => {
+    const res = await tatum.rates.getCurrentRateBatch([
+      { currency: 'BTC', basePair: 'EUR' },
+      { currency: 'ETH', basePair: 'EUR' },
+    ])
+    expect(res.data[1].value).toBeDefined()
+  })
+})

--- a/src/e2e/tatum.rpc.solana.spec.ts
+++ b/src/e2e/tatum.rpc.solana.spec.ts
@@ -1,7 +1,7 @@
-import { Commitment, Encoding, Solana } from '../dto'
-import { Network, TatumSDK } from '../service'
+import { Commitment, Encoding } from '../dto'
+import { Network, Solana, TatumSDK } from '../service'
 
-const getClient = async (testnet?: boolean) =>
+const getClient = async (testnet?: boolean): Promise<Solana> =>
   await TatumSDK.init<Solana>({
     network: testnet ? Network.SOLANA_DEVNET : Network.SOLANA,
     verbose: false,

--- a/src/e2e/tatum.rpc.spec.ts
+++ b/src/e2e/tatum.rpc.spec.ts
@@ -1,5 +1,4 @@
-import { Bitcoin, Ethereum, Polygon } from '../dto'
-import { Network, TatumSDK } from '../service'
+import { Bitcoin, Ethereum, Network, Polygon, TatumSDK } from '../service'
 
 describe('RPCs', () => {
   describe('Bitcoin', () => {

--- a/src/e2e/tatum.rpc.tron.spec.ts
+++ b/src/e2e/tatum.rpc.tron.spec.ts
@@ -1,5 +1,4 @@
-import {Network, TatumSDK} from "../service";
-import {Tron} from "../dto";
+import { Network, TatumSDK, Tron } from '../service'
 
 const getTronRpc = async (testnet?: boolean) =>
   await TatumSDK.init<Tron>({
@@ -23,18 +22,22 @@ describe('RPCs', () => {
       })
       it('getBlockByNum', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getBlock("1000000")
+        const res = await tatum.rpc.getBlock('1000000')
         expect(res.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getBlockById', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getBlock("00000000000f424013e51b18e0782a32fa079ddafdb2f4c343468cf8896dc887")
+        const res = await tatum.rpc.getBlock(
+          '00000000000f424013e51b18e0782a32fa079ddafdb2f4c343468cf8896dc887',
+        )
         expect(res.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getTransactionById', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getTransactionById("7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc")
-        expect(res.txID).toBe("7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc")
+        const res = await tatum.rpc.getTransactionById(
+          '7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc',
+        )
+        expect(res.txID).toBe('7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc')
       })
     })
     describe('mainnet', () => {
@@ -50,18 +53,22 @@ describe('RPCs', () => {
       })
       it('getBlockByNum', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getBlock("51173114")
+        const res = await tatum.rpc.getBlock('51173114')
         expect(res.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getBlockById', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getBlock("00000000030cd6faf6c282df598285c51bd61e108f98e90ea8a0ef4bd0b2d9ec")
+        const res = await tatum.rpc.getBlock(
+          '00000000030cd6faf6c282df598285c51bd61e108f98e90ea8a0ef4bd0b2d9ec',
+        )
         expect(res.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getTransactionById', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getTransactionById("eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598")
-        expect(res.txID).toBe("eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598")
+        const res = await tatum.rpc.getTransactionById(
+          'eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598',
+        )
+        expect(res.txID).toBe('eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598')
       })
     })
   })

--- a/src/e2e/tatum.rpc.xrp.spec.ts
+++ b/src/e2e/tatum.rpc.xrp.spec.ts
@@ -1,5 +1,4 @@
-import { Xrp } from '../dto'
-import { Network, TatumSDK } from '../service'
+import { Network, TatumSDK, Xrp } from '../service'
 
 const getXrpRpc = async (testnet?: boolean) =>
   await TatumSDK.init<Xrp>({

--- a/src/e2e/tatum.spec.ts
+++ b/src/e2e/tatum.spec.ts
@@ -1,5 +1,5 @@
-import { Bitcoin, Network } from '../dto'
-import { TatumSDK } from '../service'
+import { Network } from '../dto'
+import { Bitcoin, TatumSDK } from '../service'
 import { e2eUtil } from './e2e.util'
 
 describe('Tatum Init', () => {

--- a/src/e2e/tatum.token.spec.ts
+++ b/src/e2e/tatum.token.spec.ts
@@ -1,8 +1,7 @@
-import { Ethereum } from '../dto'
-import { Network, TatumSDK } from '../service'
+import { Ethereum, Network, TatumSDK } from '../service'
 
 describe('Tatum token', () => {
-  let tatum: TatumSDK<Ethereum>
+  let tatum: Ethereum
   beforeAll(async () => {
     tatum = await TatumSDK.init<Ethereum>({
       network: Network.ETHEREUM_SEPOLIA,

--- a/src/service/fee/fee.dto.ts
+++ b/src/service/fee/fee.dto.ts
@@ -1,4 +1,4 @@
-import { Chain } from '../../dto'
+import { Chain, Network } from '../../dto'
 
 export interface NativeTransferFeeEstimationDetails {
   chain: Chain
@@ -23,18 +23,27 @@ export interface EstimationsApi {
   }
 }
 
-export type CurrentFee = {
-  [key in Chain]: {
-    gasPrice: {
-      slow: string
-      medium: string
-      fast: string
-      baseFee: string
-      unit: string
-    }
-    lastRecalculated: string
-    basedOnBlockNumber: string
+export interface CurrentEvmFee {
+  chain: Network
+  gasPrice: {
+    slow: string
+    medium: string
+    fast: string
+    baseFee: string
+    unit: string
   }
+  lastRecalculated: string
+  basedOnBlockNumber: string
+}
+
+export interface CurrentUtxoFee {
+  chain: Network
+  slow: string
+  medium: string
+  fast: string
+  unit: string
+  lastRecalculated: string
+  basedOnBlockNumber: string
 }
 
 export type EmptyObject = Record<string, never>
@@ -50,4 +59,21 @@ export type NativeTransferFeeEstimation = {
     }
     gasLimit: string
   }[]
+}
+
+export interface ApiUtxoFeeResponse {
+  fast: string
+  medium: string
+  slow: string
+  time: string
+  block: string
+}
+
+export interface ApiEvmFeeResponse {
+  slow: string
+  baseFee: string
+  fast: string
+  medium: string
+  time: string
+  block: string
 }

--- a/src/service/tatum/tatum.ts
+++ b/src/service/tatum/tatum.ts
@@ -1,7 +1,8 @@
 import { Container, Service } from 'typedi'
+import { EvmBasedRpcSuite, SolanaRpcSuite, TronRpcSuite, UtxoBasedRpcSuite, XrpRpcSuite } from '../../dto/rpc'
 import { CONFIG, Utils } from '../../util'
 import { Address } from '../address'
-import { Fee } from '../fee'
+import { FeeEvm, FeeUtxo } from '../fee'
 import { Nft } from '../nft'
 import { Notification } from '../notification'
 import { Rates } from '../rate'
@@ -9,34 +10,109 @@ import { Token } from '../token'
 import { WalletProvider } from '../walletProvider'
 import { ApiVersion, TatumConfig } from './tatum.dto'
 
-@Service({ transient: true })
-export class TatumSDK<T> {
+export class BaseTatumSdk {
   notification: Notification
   nft: Nft
   token: Token
   address: Address
-  rpc: T
   walletProvider: WalletProvider
   rates: Rates
-  fee: Fee
 
-  private constructor(private readonly id: string) {
-    this.notification = Container.of(id).get(Notification)
+  constructor(private readonly id: string) {
+    this.notification = Container.of(this.id).get(Notification)
     this.nft = Container.of(id).get(Nft)
     this.token = Container.of(id).get(Token)
     this.walletProvider = Container.of(id).get(WalletProvider)
     this.address = Container.of(id).get(Address)
-    this.rpc = Utils.getRpc<T>(this.id, Container.of(id).get(CONFIG).network)
     this.rates = Container.of(id).get(Rates)
-    this.fee = Container.of(id).get(Fee)
   }
+}
 
+export abstract class BaseUtxoClass extends BaseTatumSdk {
+  rpc: UtxoBasedRpcSuite
+  fee: FeeUtxo
+
+  constructor(id: string) {
+    super(id)
+    this.rpc = Utils.getRpc<UtxoBasedRpcSuite>(id, Container.of(id).get(CONFIG).network)
+    this.fee = Container.of(id).get(FeeUtxo)
+  }
+}
+
+export abstract class BaseEvmClass extends BaseTatumSdk {
+  rpc: EvmBasedRpcSuite
+
+  constructor(id: string) {
+    super(id)
+    this.rpc = Utils.getRpc<EvmBasedRpcSuite>(id, Container.of(id).get(CONFIG).network)
+  }
+}
+
+export class Ethereum extends BaseEvmClass {
+  fee: FeeEvm
+
+  constructor(id: string) {
+    super(id)
+    this.fee = Container.of(id).get(FeeEvm)
+  }
+}
+export class ArbitrumNova extends BaseEvmClass {}
+export class ArbitrumOne extends BaseEvmClass {}
+export class Aurora extends BaseEvmClass {}
+export class AvalancheC extends BaseEvmClass {}
+export class BinanceSmartChain extends BaseEvmClass {}
+export class Celo extends BaseEvmClass {}
+export class Cronos extends BaseEvmClass {}
+export class EthereumClassic extends BaseEvmClass {}
+export class Fantom extends BaseEvmClass {}
+export class Gnosis extends BaseEvmClass {}
+export class HarmonyOne extends BaseEvmClass {}
+export class Klaytn extends BaseEvmClass {}
+export class Kucoin extends BaseEvmClass {}
+export class Oasis extends BaseEvmClass {}
+export class Optimism extends BaseEvmClass {}
+export class Palm extends BaseEvmClass {}
+export class Polygon extends BaseEvmClass {}
+export class Vechain extends BaseEvmClass {}
+export class Xdc extends BaseEvmClass {}
+
+// UTXO chains
+export class Bitcoin extends BaseUtxoClass {}
+export class Litecoin extends BaseUtxoClass {}
+export class Dogecoin extends BaseUtxoClass {}
+export class BitcoinCash extends BaseUtxoClass {}
+
+// other chains
+export class Xrp extends BaseTatumSdk {
+  rpc: XrpRpcSuite
+  constructor(id: string) {
+    super(id)
+    this.rpc = Utils.getRpc<XrpRpcSuite>(id, Container.of(id).get(CONFIG).network)
+  }
+}
+export class Solana extends BaseTatumSdk {
+  rpc: SolanaRpcSuite
+  constructor(id: string) {
+    super(id)
+    this.rpc = Utils.getRpc<SolanaRpcSuite>(id, Container.of(id).get(CONFIG).network)
+  }
+}
+export class Tron extends BaseTatumSdk {
+  rpc: TronRpcSuite
+  constructor(id: string) {
+    super(id)
+    this.rpc = Utils.getRpc<TronRpcSuite>(id, Container.of(id).get(CONFIG).network)
+  }
+}
+
+@Service({ transient: true })
+export class TatumSDK {
   /**
    * Initialize Tatum SDK. This method must be called before any other method.
    * Default configuration is used if no configuration is provided.
    * @param config
    */
-  public static async init<T>(config: TatumConfig): Promise<TatumSDK<T>> {
+  public static async init<T>(config: TatumConfig): Promise<T> {
     const defaultConfig: TatumConfig = {
       verbose: false,
       version: ApiVersion.V2,
@@ -47,7 +123,8 @@ export class TatumSDK<T> {
 
     const id = TatumSDK.generateRandomString()
     Container.of(id).set(CONFIG, defaultConfig)
-    return new TatumSDK<T>(id)
+
+    return Utils.getClient<T>(id, defaultConfig.network)
   }
 
   private static generateRandomString() {

--- a/src/service/tatum/tatum.ts
+++ b/src/service/tatum/tatum.ts
@@ -1,6 +1,7 @@
 import { Container, Service } from 'typedi'
 import { CONFIG, Utils } from '../../util'
 import { Address } from '../address'
+import { Fee } from '../fee'
 import { Nft } from '../nft'
 import { Notification } from '../notification'
 import { Rates } from '../rate'
@@ -17,6 +18,7 @@ export class TatumSDK<T> {
   rpc: T
   walletProvider: WalletProvider
   rates: Rates
+  fee: Fee
 
   private constructor(private readonly id: string) {
     this.notification = Container.of(id).get(Notification)
@@ -26,6 +28,7 @@ export class TatumSDK<T> {
     this.address = Container.of(id).get(Address)
     this.rpc = Utils.getRpc<T>(this.id, Container.of(id).get(CONFIG).network)
     this.rates = Container.of(id).get(Rates)
+    this.fee = Container.of(id).get(Fee)
   }
 
   /**

--- a/src/util/util.shared.ts
+++ b/src/util/util.shared.ts
@@ -2,12 +2,48 @@ import { Container } from 'typedi'
 import {
   AddressEventNotificationChain,
   isEvmBasedNetwork,
-  isSolanaEnabledNetwork, isTronNetwork,
+  isSolanaEnabledNetwork,
+  isTronNetwork,
   isUtxoBasedNetwork,
   isXrpNetwork,
   Network,
 } from '../dto'
-import {EvmBasedRpc, GenericRpc, SolanaRpc, TronRpc, UtxoBasedRpc, XrpRpc} from '../service'
+import {
+  ArbitrumNova,
+  ArbitrumOne,
+  Aurora,
+  AvalancheC,
+  BaseTatumSdk,
+  BinanceSmartChain,
+  Bitcoin,
+  BitcoinCash,
+  Celo,
+  Cronos,
+  Dogecoin,
+  Ethereum,
+  EthereumClassic,
+  EvmBasedRpc,
+  Fantom,
+  GenericRpc,
+  Gnosis,
+  HarmonyOne,
+  Klaytn,
+  Kucoin,
+  Litecoin,
+  Oasis,
+  Optimism,
+  Palm,
+  Polygon,
+  Solana,
+  SolanaRpc,
+  Tron,
+  TronRpc,
+  UtxoBasedRpc,
+  Vechain,
+  Xdc,
+  Xrp,
+  XrpRpc,
+} from '../service'
 
 export const Utils = {
   getRpc: <T>(id: string, network: Network): T => {
@@ -121,20 +157,110 @@ export const Utils = {
   },
   padWithZero: (data: string, length = 64) => data.replace('0x', '').padStart(length, '0'),
   camelToSnakeCase: (str: string) => str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`),
-  convertObjCamelToSnake: (obj: object)=> {
-    const snakeObj = {};
+  convertObjCamelToSnake: (obj: object) => {
+    const snakeObj = {}
     for (const [key, value] of Object.entries(obj)) {
       const snakeKey = Utils.camelToSnakeCase(key)
       if (typeof value === 'object' && value !== null) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        snakeObj[snakeKey] = convertObjCamelToSnake(value);
+        snakeObj[snakeKey] = convertObjCamelToSnake(value)
       } else {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        snakeObj[snakeKey] = value;
+        snakeObj[snakeKey] = value
       }
     }
-    return snakeObj;
-  }
+    return snakeObj
+  },
+  getClient: <T>(id: string, network: Network): T => {
+    switch (network) {
+      case Network.BITCOIN:
+      case Network.BITCOIN_TESTNET:
+        return new Bitcoin(id) as T
+      case Network.LITECOIN:
+      case Network.LITECOIN_TESTNET:
+        return new Litecoin(id) as T
+      case Network.DOGECOIN:
+      case Network.DOGECOIN_TESTNET:
+        return new Dogecoin(id) as T
+      case Network.BITCOIN_CASH:
+      case Network.BITCOIN_CASH_TESTNET:
+        return new BitcoinCash(id) as T
+      case Network.ETHEREUM:
+      case Network.ETHEREUM_SEPOLIA:
+      case Network.ETHEREUM_GOERLI:
+        return new Ethereum(id) as T
+      case Network.ETHEREUM_CLASSIC:
+        return new EthereumClassic(id) as T
+      case Network.ARBITRUM_NOVA:
+      case Network.ARBITRUM_NOVA_TESTNET:
+        return new ArbitrumNova(id) as T
+      case Network.ARBITRUM_ONE:
+        return new ArbitrumOne(id) as T
+      case Network.AURORA:
+      case Network.AURORA_TESTNET:
+        return new Aurora(id) as T
+      case Network.AVALANCHE_C:
+      case Network.AVALANCHE_C_TESTNET:
+      case Network.AVALANCHE_P:
+      case Network.AVALANCHE_P_TESTNET:
+      case Network.AVALANCHE_X:
+      case Network.AVALANCHE_X_TESTNET:
+        return new AvalancheC(id) as T
+      case Network.BINANCE_SMART_CHAIN:
+      case Network.BINANCE_SMART_CHAIN_TESTNET:
+        return new BinanceSmartChain(id) as T
+      case Network.CELO:
+      case Network.CELO_ALFAJORES:
+        return new Celo(id) as T
+      case Network.CRONOS:
+      case Network.CRONOS_TESTNET:
+        return new Cronos(id) as T
+      case Network.FANTOM:
+      case Network.FANTOM_TESTNET:
+        return new Fantom(id) as T
+      case Network.GNOSIS:
+      case Network.GNOSIS_TESTNET:
+        return new Gnosis(id) as T
+      case Network.HARMONY_ONE_SHARD_0:
+      case Network.HARMONY_ONE_TESTNET_SHARD_0:
+        return new HarmonyOne(id) as T
+      case Network.KLAYTN:
+      case Network.KLAYTN_BAOBAB:
+        return new Klaytn(id) as T
+      case Network.KUCOIN:
+      case Network.KUCOIN_TESTNET:
+        return new Kucoin(id) as T
+      case Network.OASIS:
+      case Network.OASIS_TESTNET:
+        return new Oasis(id) as T
+      case Network.OPTIMISM:
+      case Network.OPTIMISM_TESTNET:
+        return new Optimism(id) as T
+      case Network.PALM:
+      case Network.PALM_TESTNET:
+        return new Palm(id) as T
+      case Network.POLYGON:
+      case Network.POLYGON_MUMBAI:
+        return new Polygon(id) as T
+      case Network.VECHAIN:
+      case Network.VECHAIN_TESTNET:
+        return new Vechain(id) as T
+      case Network.XDC:
+      case Network.XDC_TESTNET:
+        return new Xdc(id) as T
+      case Network.XRP:
+      case Network.XRP_TESTNET:
+        return new Xrp(id) as T
+      case Network.SOLANA:
+      case Network.SOLANA_DEVNET:
+        return new Solana(id) as T
+      case Network.TRON:
+      case Network.TRON_SHASTA:
+        return new Tron(id) as T
+      default:
+        return new BaseTatumSdk(id) as T
+    }
+  },
 }


### PR DESCRIPTION
# Description

- Add fee submodule for Ethereum and Bitcoin chains. 

- Change how TatumSDK instantiates classes for blockchain specific operations. TatumSdk `init` function now returns specific blockchain class with related operations. If the chain does not support a specific module e.g. `rpc` or `fee`, it won't be part of the class.

## Type of change


- [ ] New feature, TatumSdk is not generic anymore - this is potentially a breaking change
- [ ] This change requires a documentation update

