### PR TITLE
ALL-2078 Change all RPC methods to return ResponseDto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.2] - 2023.07.04
+### Changed
+- All RPC methods are returning `ResponseDto` object with fields: `data`, `error`, `status`.
+
 ## [1.5.1] - 2023.06.28
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -33,10 +33,15 @@ Tatum SDK is a powerful, feature-rich TypeScript/JavaScript library that streaml
 With Tatum SDK, you can:
 
 ### Perform native RPC calls
+
 Easily interact with different blockchains through native RPC calls, abstracting away the complexities of managing separate RPC clients for each blockchain.
+
 ### Create notifications
+
 Monitor wallet activity with ease by setting up real-time notifications for events such as incoming and outgoing transactions, balance updates, and contract interactions.
+
 ### Access wallet information
+
 Retrieve vital wallet details, including balances, transaction history, and other relevant information, all through a single interface.
 
 Tatum SDK is constantly evolving, with new features and support for additional blockchains being added regularly.
@@ -98,8 +103,8 @@ import { TatumSDK, Network, Ethereum } from '@tatumcom/js'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 
-const balance = await tatum.rpc.getBalance('0x742d35Cc6634C0532925a3b844Bc454e4438f44e')
-console.log(`Balance: ${balance}`)
+const { data } = await tatum.rpc.getBalance('0x742d35Cc6634C0532925a3b844Bc454e4438f44e')
+console.log(`Balance: ${data}`)
 ```
 
 ### Subscribing to Notifications
@@ -212,14 +217,15 @@ console.log(balances)
 
 ## Documentation
 
- - [Documentation and Guides](https://docs.tatum.com) to get started with Tatum SDK
- - [Documentation section](https://github.com/tatumio/tatum-js/tree/master/docs) for more details.
+- [Documentation and Guides](https://docs.tatum.com) to get started with Tatum SDK
+- [Documentation section](https://github.com/tatumio/tatum-js/tree/master/docs) for more details.
 
 ## Examples
-  - [Browser Example](https://github.com/tatumio/tatum-js/tree/master/examples/browser)
-  - [Get Balance ETH Example](https://github.com/tatumio/tatum-js/tree/master/examples/docs/get-balance-eth)
-  - [NextJS Example](https://github.com/tatumio/tatum-js/tree/master/examples/nextjs)
-  - [TypeScript Example](https://github.com/tatumio/tatum-js/tree/master/examples/typescript)
+
+- [Browser Example](https://github.com/tatumio/tatum-js/tree/master/examples/browser)
+- [Get Balance ETH Example](https://github.com/tatumio/tatum-js/tree/master/examples/docs/get-balance-eth)
+- [NextJS Example](https://github.com/tatumio/tatum-js/tree/master/examples/nextjs)
+- [TypeScript Example](https://github.com/tatumio/tatum-js/tree/master/examples/typescript)
 
 ## Legacy versions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumcom/js",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/dto/rpc/EvmBasedRpcInterface.ts
+++ b/src/dto/rpc/EvmBasedRpcInterface.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BigNumber } from 'bignumber.js'
+import { ResponseDto } from '../../util'
 import { AbstractRpcInterface } from './AbstractJsonRpcInterface'
 
 /**
@@ -70,73 +71,72 @@ export interface EvmBasedRpcSuite extends EvmBasedRpcInterface, AbstractRpcInter
 
 export interface EvmBasedRpcInterface {
   // eth_ methods
-  blockNumber(): Promise<BigNumber>
+  blockNumber(): Promise<ResponseDto<BigNumber>>
 
-  call(callObject: TxPayload, blockNumber?: BlockNumber): Promise<string>
+  call(callObject: TxPayload, blockNumber?: BlockNumber): Promise<ResponseDto<string>>
 
-  chainId(): Promise<BigNumber>
+  chainId(): Promise<ResponseDto<BigNumber>>
 
-  estimateGas(callObject: TxPayload): Promise<BigNumber>
+  estimateGas(callObject: TxPayload): Promise<ResponseDto<BigNumber>>
 
-  gasPrice(): Promise<BigNumber>
+  gasPrice(): Promise<ResponseDto<BigNumber>>
 
-  maxPriorityFeePerGas(): Promise<BigNumber>
+  maxPriorityFeePerGas(): Promise<ResponseDto<BigNumber>>
 
-  getBalance(address: string, blockNumber?: BlockNumber): Promise<BigNumber>
+  getBalance(address: string, blockNumber?: BlockNumber): Promise<ResponseDto<BigNumber>>
 
-  getBlockByHash(blockHash: string, includeTransactions?: boolean): Promise<any>
+  getBlockByHash(blockHash: string, includeTransactions?: boolean): Promise<ResponseDto<any>>
+  getBlockTransactionCountByHash(blockHash: string): Promise<ResponseDto<number>>
 
-  getBlockTransactionCountByHash(blockHash: string): Promise<number>
+  getBlockByNumber(blockNumber: string | number, includeTransactions?: boolean): Promise<ResponseDto<any>>
 
-  getBlockByNumber(blockNumber: string | number, includeTransactions?: boolean): Promise<any>
+  getBlockTransactionCountByNumber(blockNumber: string | number): Promise<ResponseDto<number>>
 
-  getBlockTransactionCountByNumber(blockNumber: string | number): Promise<number>
+  getCode(address: string, blockNumber?: BlockNumber): Promise<ResponseDto<string>>
 
-  getCode(address: string, blockNumber?: BlockNumber): Promise<string>
+  getLogs(filterObject: LogFilter): Promise<ResponseDto<any>>
 
-  getLogs(filterObject: LogFilter): Promise<any>
+  getProof(address: string, storageKeys: string[], blockNumber?: BlockNumber): Promise<ResponseDto<any>>
 
-  getProof(address: string, storageKeys: string[], blockNumber?: BlockNumber): Promise<any>
+  getStorageAt(address: string, position: string, blockNumber?: BlockNumber): Promise<ResponseDto<string>>
 
-  getStorageAt(address: string, position: string, blockNumber?: BlockNumber): Promise<string>
+  getTransactionByBlockHashAndIndex(blockHash: string, index: number): Promise<ResponseDto<any>>
 
-  getTransactionByBlockHashAndIndex(blockHash: string, index: number): Promise<any>
+  getTransactionByBlockNumberAndIndex(blockNumber: string | number, index: number): Promise<ResponseDto<any>>
 
-  getTransactionByBlockNumberAndIndex(blockNumber: string | number, index: number): Promise<any>
+  getTransactionByHash(txHash: string): Promise<ResponseDto<any>>
 
-  getTransactionByHash(txHash: string): Promise<any>
+  getTransactionCount(address: string, blockNumber?: BlockNumber): Promise<ResponseDto<BigNumber>>
 
-  getTransactionCount(address: string, blockNumber?: BlockNumber): Promise<BigNumber>
+  getTransactionReceipt(txHash: string): Promise<ResponseDto<any>>
 
-  getTransactionReceipt(txHash: string): Promise<any>
+  getUncleByBlockHashAndIndex(blockHash: string, index: number): Promise<ResponseDto<any>>
 
-  getUncleByBlockHashAndIndex(blockHash: string, index: number): Promise<any>
+  getUncleByBlockNumberAndIndex(blockNumber: string | number, index: number): Promise<ResponseDto<any>>
 
-  getUncleByBlockNumberAndIndex(blockNumber: string | number, index: number): Promise<any>
+  getUncleCountByBlockHash(blockHash: string): Promise<ResponseDto<string>>
 
-  getUncleCountByBlockHash(blockHash: string): Promise<string>
+  getUncleCountByBlockNumber(blockNumber: string | number): Promise<ResponseDto<string>>
 
-  getUncleCountByBlockNumber(blockNumber: string | number): Promise<string>
+  protocolVersion(): Promise<ResponseDto<string>>
 
-  protocolVersion(): Promise<string>
+  sendRawTransaction(signedTransactionData: string): Promise<ResponseDto<string>>
 
-  sendRawTransaction(signedTransactionData: string): Promise<string>
-
-  syncing(): Promise<any>
+  syncing(): Promise<ResponseDto<any>>
 
   // Custom helper functions, not part of the RPC node
 
-  getTokenDecimals(tokenAddress: string): Promise<BigNumber>
+  getTokenDecimals(tokenAddress: string): Promise<ResponseDto<BigNumber>>
 
-  getContractAddress(txHash: string): Promise<string | null>
+  getContractAddress(txHash: string): Promise<ResponseDto<string | null>>
 
   // web3_ methods
-  clientVersion(): Promise<string>
+  clientVersion(): Promise<ResponseDto<string>>
 
-  sha3(data: string): Promise<string>
+  sha3(data: string): Promise<ResponseDto<string>>
 
   // debug_ methods
-  debugGetBadBlocks(): Promise<any>
+  debugGetBadBlocks(): Promise<ResponseDto<any>>
 
   debugStorageRangeAt(
     blockHash: string,
@@ -144,35 +144,47 @@ export interface EvmBasedRpcInterface {
     contractAddress: string,
     startKey: string,
     maxResult: string,
-  ): Promise<any>
+  ): Promise<ResponseDto<any>>
 
-  debugTraceCall(callObject: TxPayload, blockNumber: BlockNumber, traceOptions?: TraceOptions): Promise<any>
+  debugTraceCall(
+    callObject: TxPayload,
+    blockNumber: BlockNumber,
+    traceOptions?: TraceOptions,
+  ): Promise<ResponseDto<any>>
 
-  debugTraceTransaction(txHash: string, traceOptions?: TraceOptions): Promise<any>
+  debugTraceTransaction(txHash: string, traceOptions?: TraceOptions): Promise<ResponseDto<any>>
 
-  debugTraceBlockByHash(blockHash: string, traceOptions?: TraceOptions): Promise<any>
+  debugTraceBlockByHash(blockHash: string, traceOptions?: TraceOptions): Promise<ResponseDto<any>>
 
-  debugTraceBlockByNumber(blockHash: string | number, traceOptions?: TraceOptions): Promise<any>
+  debugTraceBlockByNumber(blockHash: string | number, traceOptions?: TraceOptions): Promise<ResponseDto<any>>
 
   // trace_ methods
-  traceBlock(blockNumber: BlockNumber): Promise<any>
+  traceBlock(blockNumber: BlockNumber): Promise<ResponseDto<any>>
 
-  traceCall(callObject: TxPayload, traceType: TraceType[], blockNumber: BlockNumber): Promise<any>
+  traceCall(
+    callObject: TxPayload,
+    traceType: TraceType[],
+    blockNumber: BlockNumber,
+  ): Promise<ResponseDto<any>>
 
-  traceCallMany(callObject: TxPayload[], traceType: TraceType[][], blockNumber: BlockNumber): Promise<any>
+  traceCallMany(
+    callObject: TxPayload[],
+    traceType: TraceType[][],
+    blockNumber: BlockNumber,
+  ): Promise<ResponseDto<any>>
 
-  traceRawTransaction(signedTransactionData: string, traceOptions: TraceType[]): Promise<any>
+  traceRawTransaction(signedTransactionData: string, traceOptions: TraceType[]): Promise<ResponseDto<any>>
 
-  traceReplayBlockTransactions(blockNumber: BlockNumber, traceOptions: TraceType[]): Promise<any>
+  traceReplayBlockTransactions(blockNumber: BlockNumber, traceOptions: TraceType[]): Promise<ResponseDto<any>>
 
-  traceReplayTransaction(txHash: string, traceOptions: TraceType[]): Promise<any>
+  traceReplayTransaction(txHash: string, traceOptions: TraceType[]): Promise<ResponseDto<any>>
 
-  traceTransaction(txHash: string): Promise<any>
+  traceTransaction(txHash: string): Promise<ResponseDto<any>>
 
   // txpool_ methods
-  txPoolContent(): Promise<any>
+  txPoolContent(): Promise<ResponseDto<any>>
 
-  txPoolStatus(): Promise<any>
+  txPoolStatus(): Promise<ResponseDto<any>>
 
-  txPoolInspect(): Promise<any>
+  txPoolInspect(): Promise<ResponseDto<any>>
 }

--- a/src/dto/rpc/SolanaRpcSuite.ts
+++ b/src/dto/rpc/SolanaRpcSuite.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ResponseDto } from '../../util'
 import { AbstractRpcInterface } from './AbstractJsonRpcInterface'
 
 export interface SolanaAccountInfo {
@@ -294,21 +295,21 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getAccountInfo: (
     pubkey: string,
     options?: GetAccountInfoOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaAccountInfo | null>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaAccountInfo | null>>>
 
   /**
    * Get balance of the account on the Solana blockchain.
    * @param publicKey - Pubkey of account to query, as base-58 encoded string
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-querying-account-information/getbalance
    */
-  getBalance: (publicKey: string) => Promise<SolanaTypeWithContext<number>>
+  getBalance: (publicKey: string) => Promise<ResponseDto<SolanaTypeWithContext<number>>>
 
   /**
    * Get the latest block height.
    * @param options - Options for the query
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getblockheight
    */
-  getBlockHeight: (options?: GetCommitmentMinContextSlotOptions) => Promise<number>
+  getBlockHeight: (options?: GetCommitmentMinContextSlotOptions) => Promise<ResponseDto<number>>
 
   /**
    * Get information about a specific block.
@@ -319,16 +320,18 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getBlock: (
     block: number,
     options?: GetBlockOptions,
-  ) => Promise<{
-    blockhash: string
-    previousBlockhash: string
-    parentSlot: number
-    transactions: Array<any>
-    signatures: Array<any>
-    rewards: Array<any> | undefined
-    blockTime: number | null
-    blockHeight: number | null
-  } | null>
+  ) => Promise<
+    ResponseDto<{
+      blockhash: string
+      previousBlockhash: string
+      parentSlot: number
+      transactions: Array<any>
+      signatures: Array<any>
+      rewards: Array<any> | undefined
+      blockTime: number | null
+      blockHeight: number | null
+    } | null>
+  >
 
   /**
    * Get block production information.
@@ -337,14 +340,16 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    */
   getBlockProduction: (
     options?: GetBlockProductionOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaBlockProduction>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaBlockProduction>>>
 
   /**
    * Get block commitment information.
    * @param block - Block number, identified by Slot
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getblockcommitment
    */
-  getBlockCommitment: (block: number) => Promise<{ commitment: Array<number>; totalStake: number }>
+  getBlockCommitment: (
+    block: number,
+  ) => Promise<ResponseDto<{ commitment: Array<number>; totalStake: number }>>
 
   /**
    * Get blocks information.
@@ -353,29 +358,35 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param options - Options for the query
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getblocks
    */
-  getBlocks: (endSlot: number, startSlot?: number, options?: GetCommitmentOptions) => Promise<Array<number>>
+  getBlocks: (
+    endSlot: number,
+    startSlot?: number,
+    options?: GetCommitmentOptions,
+  ) => Promise<ResponseDto<Array<number>>>
 
   /**
    * Get block time information.
    * @param block - Block number, identified by Slot
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getblocktime
    */
-  getBlockTime: (block: number) => Promise<number | null>
+  getBlockTime: (block: number) => Promise<ResponseDto<number | null>>
 
   /**
    * Get cluster nodes information.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getclusternodes
    */
   getClusterNodes: () => Promise<
-    Array<{
-      pubkey: string
-      gossip?: string
-      tpu?: string
-      rpc?: string
-      version?: string
-      featureSet?: number
-      shredVersion?: number
-    }>
+    ResponseDto<
+      Array<{
+        pubkey: string
+        gossip?: string
+        tpu?: string
+        rpc?: string
+        version?: string
+        featureSet?: number
+        shredVersion?: number
+      }>
+    >
   >
 
   /**
@@ -383,13 +394,13 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param options - Options for the query
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getepochinfo
    */
-  getEpochInfo: (options?: GetCommitmentMinContextSlotOptions) => Promise<SolanaEpochInfo>
+  getEpochInfo: (options?: GetCommitmentMinContextSlotOptions) => Promise<ResponseDto<SolanaEpochInfo>>
 
   /**
    * Get epoch schedule.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getepochschedule
    */
-  getEpochSchedule: () => Promise<SolanaEpochSchedule>
+  getEpochSchedule: () => Promise<ResponseDto<SolanaEpochSchedule>>
 
   /**
    * Retrieve the minimum fee required to include a message in a block.
@@ -397,56 +408,63 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param options - Options for the query.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-transaction-management/getfeeformessage
    */
-  getFeeForMessage: (message: any, options?: GetCommitmentMinContextSlotOptions) => Promise<number | null>
+  getFeeForMessage: (
+    message: any,
+    options?: GetCommitmentMinContextSlotOptions,
+  ) => Promise<ResponseDto<number | null>>
 
   /**
    * Get the first available block on the Solana blockchain.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getfirstavailableblock
    */
-  getFirstAvailableBlock: () => Promise<number>
+  getFirstAvailableBlock: () => Promise<ResponseDto<number>>
 
   /**
    * Get the Genesis Hash of the Solana blockchain.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getgenesishash
    */
-  getGenesisHash: () => Promise<string>
+  getGenesisHash: () => Promise<ResponseDto<string>>
 
   /**
    * Get the health status of the Solana cluster.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/gethealth
    */
-  getHealth: () => Promise<string>
+  getHealth: () => Promise<ResponseDto<string>>
 
   /**
    * Get the highest available snapshot slot on the Solana cluster.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/gethighestsnapshotslot
    */
-  getHighestSnapshotSlot: () => Promise<{ full: number; incremental: number }>
+  getHighestSnapshotSlot: () => Promise<ResponseDto<{ full: number; incremental: number }>>
 
   /**
    * Get the identity pubkey of the node.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getidentity
    */
-  getIdentity: () => Promise<{ identity: string }>
+  getIdentity: () => Promise<ResponseDto<{ identity: string }>>
 
   /**
    * Get the current inflation governor's rates.
    * @param options - Options for the query.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-querying-token-and-stake-information/getinflationgovernor
    */
-  getInflationGovernor: (options?: GetCommitmentOptions) => Promise<{
-    initial: number
-    terminal: number
-    taper: number
-    foundation: number
-    foundationTerm: number
-  }>
+  getInflationGovernor: (options?: GetCommitmentOptions) => Promise<
+    ResponseDto<{
+      initial: number
+      terminal: number
+      taper: number
+      foundation: number
+      foundationTerm: number
+    }>
+  >
 
   /**
    * Get the current inflation rate on the Solana blockchain.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-querying-token-and-stake-information/getinflationrate
    */
-  getInflationRate: () => Promise<{ total: number; validator: number; foundation: number; epoch: number }>
+  getInflationRate: () => Promise<
+    ResponseDto<{ total: number; validator: number; foundation: number; epoch: number }>
+  >
 
   /**
    * Get the inflation reward for specified addresses.
@@ -458,13 +476,15 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
     addresses?: string[],
     options?: GetInflationRewardOptions,
   ) => Promise<
-    Array<{
-      epoch: number
-      effectiveSlot: number
-      amount: number
-      postBalance: number
-      commission: number
-    }>
+    ResponseDto<
+      Array<{
+        epoch: number
+        effectiveSlot: number
+        amount: number
+        postBalance: number
+        commission: number
+      }>
+    >
   >
 
   /**
@@ -474,7 +494,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    */
   getLargestAccounts: (
     options?: GetLargestAccountsOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaLargestAccount[]>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaLargestAccount[]>>>
 
   /**
    * Fetches the latest block hash from the Solana blockchain.
@@ -483,7 +503,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    */
   getLatestBlockhash: (
     options?: GetCommitmentMinContextSlotOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaLatestBlockhash>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaLatestBlockhash>>>
 
   /**
    * Fetches the leader schedule for the Solana blockchain.
@@ -494,19 +514,19 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getLeaderSchedule: (
     slot?: number,
     options?: GetLeaderScheduleOptions,
-  ) => Promise<SolanaLeaderSchedule | null>
+  ) => Promise<ResponseDto<SolanaLeaderSchedule | null>>
 
   /**
    * Retrieves the max slot number seen from retransmit stage.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getmaxretransmitslot
    */
-  getMaxRetransmitSlot: () => Promise<number>
+  getMaxRetransmitSlot: () => Promise<ResponseDto<number>>
 
   /**
    * Retrieves the max slot number seen from after shred insert.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getmaxshredinsertslot
    */
-  getMaxShredInsertSlot: () => Promise<number>
+  getMaxShredInsertSlot: () => Promise<ResponseDto<number>>
 
   /**
    * Gets the minimum balance required for rent exemption for an account.
@@ -514,7 +534,10 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param options - The options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getminimumbalanceforrentexemption
    */
-  getMinimumBalanceForRentExemption: (dataSize?: number, options?: GetCommitmentOptions) => Promise<number>
+  getMinimumBalanceForRentExemption: (
+    dataSize?: number,
+    options?: GetCommitmentOptions,
+  ) => Promise<ResponseDto<number>>
 
   /**
    * Fetches multiple accounts on the Solana blockchain.
@@ -525,7 +548,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getMultipleAccounts: (
     pubKeys: string[],
     options?: GetMultipleAccountsOptions,
-  ) => Promise<SolanaTypeWithContext<Array<SolanaAccountInfo | null>>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<Array<SolanaAccountInfo | null>>>>
 
   /**
    * Fetches program accounts from the Solana blockchain.
@@ -536,7 +559,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getProgramAccounts: (
     programId: string,
     options?: GetProgramAccountsOptions,
-  ) => Promise<Array<{ account: SolanaAccountInfo; pubkey: string }>>
+  ) => Promise<ResponseDto<Array<{ account: SolanaAccountInfo; pubkey: string }>>>
 
   /**
    * Gets recent performance samples.
@@ -544,13 +567,15 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getrecentperformancesamples
    */
   getRecentPerformanceSamples: (limit?: number) => Promise<
-    Array<{
-      slot: number
-      numTransactions: number
-      numSlots: number
-      samplePeriodSecs: number
-      numNonVoteTransaction: number
-    }>
+    ResponseDto<
+      Array<{
+        slot: number
+        numTransactions: number
+        numSlots: number
+        samplePeriodSecs: number
+        numNonVoteTransaction: number
+      }>
+    >
   >
 
   /**
@@ -560,7 +585,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    */
   getRecentPrioritizationFees: (
     addresses?: string[],
-  ) => Promise<Array<{ slot: number; prioritizationFee: number }>>
+  ) => Promise<ResponseDto<Array<{ slot: number; prioritizationFee: number }>>>
 
   /**
    * Fetches the transaction signatures for a specific account address.
@@ -572,14 +597,16 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
     address: string,
     options?: GetSignaturesForAddressOptions,
   ) => Promise<
-    Array<{
-      signature: string
-      slot: number
-      err: any | null
-      memo: string | null
-      blockTime: number | null
-      confirmationStatus: string | null
-    }>
+    ResponseDto<
+      Array<{
+        signature: string
+        slot: number
+        err: any | null
+        memo: string | null
+        blockTime: number | null
+        confirmationStatus: string | null
+      }>
+    >
   >
 
   /**
@@ -591,21 +618,21 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getSignatureStatuses: (
     signatures?: string[],
     options?: GetSignatureStatusesOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaSignatureStatus>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaSignatureStatus>>>
 
   /**
    * Fetches the current slot number of the cluster.
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getslot
    */
-  getSlot: (options?: GetCommitmentMinContextSlotOptions) => Promise<number>
+  getSlot: (options?: GetCommitmentMinContextSlotOptions) => Promise<ResponseDto<number>>
 
   /**
    * Fetches the current leader of the slot.
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getslotleader
    */
-  getSlotLeader: (options?: GetCommitmentMinContextSlotOptions) => Promise<string>
+  getSlotLeader: (options?: GetCommitmentMinContextSlotOptions) => Promise<ResponseDto<string>>
 
   /**
    * Fetches the current leaders of the slot within a certain limit.
@@ -613,7 +640,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param limit - Limit (between 1 and 5,000)
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/getslotleaders
    */
-  getSlotLeaders: (startSlot?: number, limit?: number) => Promise<Array<string>>
+  getSlotLeaders: (startSlot?: number, limit?: number) => Promise<ResponseDto<Array<string>>>
 
   /**
    * Fetches the stake activation details for the specified account.
@@ -624,21 +651,23 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getStakeActivation: (
     pubkey: string,
     options?: GetStakeActivationOptions,
-  ) => Promise<{ state: string; active: number; inactive: number }>
+  ) => Promise<ResponseDto<{ state: string; active: number; inactive: number }>>
 
   /**
    * Fetches the minimum stake delegation.
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-querying-token-and-stake-information/getstakeminimumdelegation
    */
-  getStakeMinimumDelegation: (options?: GetCommitmentOptions) => Promise<SolanaTypeWithContext<number>>
+  getStakeMinimumDelegation: (
+    options?: GetCommitmentOptions,
+  ) => Promise<ResponseDto<SolanaTypeWithContext<number>>>
 
   /**
    * Fetches the current supply of the Solana network.
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getsupply
    */
-  getSupply: (options?: GetSupplyOptions) => Promise<SolanaTypeWithContext<SolanaSupply>>
+  getSupply: (options?: GetSupplyOptions) => Promise<ResponseDto<SolanaTypeWithContext<SolanaSupply>>>
 
   /**
    * Fetches the balance of the specified token account.
@@ -649,7 +678,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getTokenAccountBalance: (
     pubkey: string,
     options?: GetCommitmentOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaTokenAccountBalance>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenAccountBalance>>>
 
   /**
    * Fetches token accounts by delegate.
@@ -662,7 +691,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
     pubkey: string,
     config?: SolanaMint | SolanaProgramId,
     options?: GetTokenAccountsOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaTokenAccount[]>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenAccount[]>>>
 
   /**
    * Fetches token accounts by owner.
@@ -675,7 +704,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
     pubkey: string,
     config?: SolanaMint | SolanaProgramId,
     options?: GetTokenAccountsOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaTokenAccount[]>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenAccount[]>>>
 
   /**
    * Fetches largest token accounts for a mint.
@@ -686,7 +715,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getTokenLargestAccounts: (
     pubkey: string,
     options?: GetCommitmentOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaAccount[]>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaAccount[]>>>
 
   /**
    * Fetches token supply details for a mint.
@@ -697,7 +726,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   getTokenSupply: (
     pubkey: string,
     options?: GetCommitmentOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaTokenSupply>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenSupply>>>
 
   /**
    * Fetches a specific transaction by signature.
@@ -705,20 +734,23 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-transaction-management/gettransaction
    */
-  getTransaction: (signature: string, options?: GetTransactionOptions) => Promise<SolanaTransaction | null>
+  getTransaction: (
+    signature: string,
+    options?: GetTransactionOptions,
+  ) => Promise<ResponseDto<SolanaTransaction | null>>
 
   /**
    * Fetches the current transaction count.
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-transaction-management/gettransactioncount
    */
-  getTransactionCount: (options?: GetCommitmentMinContextSlotOptions) => Promise<number>
+  getTransactionCount: (options?: GetCommitmentMinContextSlotOptions) => Promise<ResponseDto<number>>
 
   /**
    * Fetches the current version of the Solana core software.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/getversion
    */
-  getVersion: () => Promise<SolanaVersion>
+  getVersion: () => Promise<ResponseDto<SolanaVersion>>
 
   /**
    * Fetches vote accounts information.
@@ -727,7 +759,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    */
   getVoteAccounts: (
     options?: GetVoteAccountOptions,
-  ) => Promise<{ current: Array<SolanaVoteAccount>; delinquent: Array<SolanaVoteAccount> }>
+  ) => Promise<ResponseDto<{ current: Array<SolanaVoteAccount>; delinquent: Array<SolanaVoteAccount> }>>
 
   /**
    * Checks if a blockhash is valid.
@@ -738,13 +770,13 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   isBlockhashValid: (
     blockhash: string,
     options?: GetCommitmentMinContextSlotOptions,
-  ) => Promise<SolanaTypeWithContext<boolean>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<boolean>>>
 
   /**
    * Fetches the lowest slot that the node has information about in its ledger.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-ledger-and-block-information/minimumledgerslot
    */
-  minimumLedgerSlot: () => Promise<number>
+  minimumLedgerSlot: () => Promise<ResponseDto<number>>
 
   /**
    * Requests an airdrop of lamports to a given pubkey.
@@ -753,7 +785,11 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/miscellaneous-api-calls/requestairdrop
    */
-  requestAirdrop: (pubkey: string, amount: number, options?: GetCommitmentOptions) => Promise<string>
+  requestAirdrop: (
+    pubkey: string,
+    amount: number,
+    options?: GetCommitmentOptions,
+  ) => Promise<ResponseDto<string>>
 
   /**
    * Sends a transaction to the Solana blockchain.
@@ -761,7 +797,7 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/solana-rpc-documentation/api-calls-for-transaction-management/sendtransaction
    */
-  sendTransaction: (transaction: string, options?: SendTransactionOptions) => Promise<string>
+  sendTransaction: (transaction: string, options?: SendTransactionOptions) => Promise<ResponseDto<string>>
 
   /**
    * Simulates a transaction on the Solana blockchain.
@@ -772,5 +808,5 @@ export interface SolanaRpcSuite extends AbstractRpcInterface {
   simulateTransaction: (
     transaction: string,
     options?: SimulateTransactionOptions,
-  ) => Promise<SolanaTypeWithContext<SolanaTransactionSimulation>>
+  ) => Promise<ResponseDto<SolanaTypeWithContext<SolanaTransactionSimulation>>>
 }

--- a/src/dto/rpc/TronRpcSuite.ts
+++ b/src/dto/rpc/TronRpcSuite.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {BigNumber} from "bignumber.js";
+import { BigNumber } from 'bignumber.js'
+import { ResponseDto } from '../../util'
 import { AbstractRpcInterface } from './AbstractJsonRpcInterface'
 
 export interface TronTxRawBody {
@@ -16,20 +17,20 @@ export interface TronPrices {
 
 export enum TronStakeType {
   BANDWIDTH = 'BANDWIDTH',
-  ENERGY = 'ENERGY'
+  ENERGY = 'ENERGY',
 }
 
 export enum TronStakeTypeNumeric {
   BANDWIDTH = 0,
-  ENERGY = 1
+  ENERGY = 1,
 }
 
 export interface TronPermission {
-  type: number,
-  permissionName: string,
-  threshold: number,
-  operations: string,
-  keys: Array<{ address: string, weight: number }>
+  type: number
+  permissionName: string
+  threshold: number
+  operations: string
+  keys: Array<{ address: string; weight: number }>
 }
 
 export interface VisibleOption {
@@ -47,11 +48,9 @@ export interface ExtraDataOption {
   extraData?: string
 }
 
-export interface CreateTransactionOptions extends VisibleOption, PermissionIdOption, ExtraDataOption {
-}
+export interface CreateTransactionOptions extends VisibleOption, PermissionIdOption, ExtraDataOption {}
 
-export interface VisibleAndPermissionIdOptions extends VisibleOption, PermissionIdOption {
-}
+export interface VisibleAndPermissionIdOptions extends VisibleOption, PermissionIdOption {}
 
 export interface AccountPermissionUpdateOptions extends VisibleOption {
   // witness permission
@@ -78,8 +77,7 @@ export interface DetailOption {
   detail?: boolean
 }
 
-export interface TransferAssetIssueByAccountOptions extends VisibleAndPermissionIdOptions, ExtraDataOption {
-}
+export interface TransferAssetIssueByAccountOptions extends VisibleAndPermissionIdOptions, ExtraDataOption {}
 
 export interface CreateAssetIssueOptions extends VisibleOption {
   // Token free asset net limit
@@ -88,7 +86,7 @@ export interface CreateAssetIssueOptions extends VisibleOption {
   publicFreeAssetNetLimit?: BigNumber
   // Token frozen supply
   frozenSupply?: {
-    frozen_amount: BigNumber,
+    frozen_amount: BigNumber
     frozen_days: number
   }
   precision?: number
@@ -116,18 +114,18 @@ export interface TriggerConstantContractOptions extends VisibleOption {
 }
 
 export interface DeployContractOptions extends VisibleAndPermissionIdOptions {
-  feeLimit: BigNumber,
-  parameter: string,
-  originEnergyLimit: BigNumber,
-  callValue: BigNumber,
-  consumeUserResourcePercent: number,
+  feeLimit: BigNumber
+  parameter: string
+  originEnergyLimit: BigNumber
+  callValue: BigNumber
+  consumeUserResourcePercent: number
 }
 export interface AccountIdentifier {
   address: string
 }
 
 export interface BlockIdentifier {
-  hash: string,
+  hash: string
   number: BigNumber
 }
 
@@ -140,7 +138,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with validation result.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-address-utility-methods/validateaddress
    */
-  validateAddress(address: string, options?: VisibleOption): Promise<any>
+  validateAddress(address: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Broadcasts a raw Tron transaction.
@@ -149,7 +147,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the broadcast result.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-transaction-methods/broadcasttransaction
    */
-  broadcastTransaction(rawBody: TronTxRawBody): Promise<any>
+  broadcastTransaction(rawBody: TronTxRawBody): Promise<ResponseDto<any>>
 
   /**
    * Broadcasts a transaction in hexadecimal format.
@@ -158,7 +156,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the broadcast result.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-transaction-methods/broadcasthex
    */
-  broadcastHex(transaction: string): Promise<any>
+  broadcastHex(transaction: string): Promise<ResponseDto<any>>
 
   /**
    * Creates a Tron transaction.
@@ -170,7 +168,12 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the created transaction.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-transaction-methods/createtransaction
    */
-  createTransaction(ownerAddress: string, toAddress: string, amount: BigNumber, options?: CreateTransactionOptions): Promise<any>
+  createTransaction(
+    ownerAddress: string,
+    toAddress: string,
+    amount: BigNumber,
+    options?: CreateTransactionOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Creates a Tron account.
@@ -181,7 +184,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the created account.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-methods/createaccount
    */
-  createAccount(ownerAddress: string, accountAddress: string, options?: VisibleAndPermissionIdOptions): Promise<any>
+  createAccount(
+    ownerAddress: string,
+    accountAddress: string,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Gets the details of a specific account.
@@ -191,7 +198,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the account details.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-methods/getaccount
    */
-  getAccount(address: string, options?: VisibleOption): Promise<any>
+  getAccount(address: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Updates an existing Tron account.
@@ -202,7 +209,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the update is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-methods/updateaccount
    */
-  updateAccount(ownerAddress: string, accountName: string, options?: VisibleAndPermissionIdOptions): Promise<any>
+  updateAccount(
+    ownerAddress: string,
+    accountName: string,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Updates the permissions of an account.
@@ -214,7 +225,12 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the update is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-methods/accountpermissionupdate
    */
-  accountPermissionUpdate(ownerAddress: string, actives: TronPermission[], owner: TronPermission, options?: AccountPermissionUpdateOptions): Promise<any>
+  accountPermissionUpdate(
+    ownerAddress: string,
+    actives: TronPermission[],
+    owner: TronPermission,
+    options?: AccountPermissionUpdateOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Gets the balance of a specific account.
@@ -225,7 +241,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the account balance.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-methods/getaccountbalance
    */
-  getAccountBalance(accountIdentifier: AccountIdentifier, blockIdentifier: BlockIdentifier, options?: VisibleOption): Promise<any>
+  getAccountBalance(
+    accountIdentifier: AccountIdentifier,
+    blockIdentifier: BlockIdentifier,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Fetches the resources of a given account.
@@ -235,7 +255,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the account resources.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getaccountresource
    */
-  getAccountResources(address: string, options?: VisibleOption): Promise<any>
+  getAccountResources(address: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches the net resources of a given account.
@@ -245,7 +265,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the account net resources.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getaccountnet
    */
-  getAccountNet(address: string, options?: VisibleOption): Promise<any>
+  getAccountNet(address: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Freezes balance of a given account.
@@ -258,7 +278,13 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the freeze is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/freezebalance
    */
-  freezeBalance(ownerAddress: string, frozenBalance: BigNumber, frozenDuration: number, resource: TronStakeType, options?: FreezeAccountOptions): Promise<any>
+  freezeBalance(
+    ownerAddress: string,
+    frozenBalance: BigNumber,
+    frozenDuration: number,
+    resource: TronStakeType,
+    options?: FreezeAccountOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Unfreezes the balance of a given account.
@@ -269,7 +295,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the unfreeze is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/unfreezebalance
    */
-  unfreezeBalance(ownerAddress: string, resource: TronStakeType, options?: UnFreezeAccountOptions): Promise<any>
+  unfreezeBalance(
+    ownerAddress: string,
+    resource: TronStakeType,
+    options?: UnFreezeAccountOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Fetches the delegated resource from a specified address to another.
@@ -280,7 +310,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the delegated resources.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getdelegatedresource
    */
-  getDelegatedResource(fromAddress: string, toAddress: string, options?: VisibleOption): Promise<any>
+  getDelegatedResource(
+    fromAddress: string,
+    toAddress: string,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Fetches the account index of the delegated resource.
@@ -290,7 +324,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the account index of the delegated resource.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getdelegatedresourceaccountindex
    */
-  getDelegatedResourceAccountIndex(value: string, options?: VisibleOption): Promise<any>
+  getDelegatedResourceAccountIndex(value: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Freezes the balance of a given account, version 2.
@@ -302,7 +336,12 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the freeze is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/freezebalancev2
    */
-  freezeBalanceV2(ownerAddress: string, frozenBalance: BigNumber, resource: TronStakeType, options?: VisibleAndPermissionIdOptions): Promise<any>
+  freezeBalanceV2(
+    ownerAddress: string,
+    frozenBalance: BigNumber,
+    resource: TronStakeType,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Unfreezes the balance of a given account, version 2.
@@ -314,7 +353,12 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the unfreeze is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/unfreezebalancev2
    */
-  unfreezeBalanceV2(ownerAddress: string, unfreezeBalance: BigNumber, resource: TronStakeType, options?: VisibleAndPermissionIdOptions): Promise<any>
+  unfreezeBalanceV2(
+    ownerAddress: string,
+    unfreezeBalance: BigNumber,
+    resource: TronStakeType,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Delegates a resource from one account to another.
@@ -328,7 +372,14 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the delegation is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/delegateresource
    */
-  delegateResource(ownerAddress: string, receiverAddress: string, balance: BigNumber, resource: TronStakeType, lock: boolean, options?: VisibleAndPermissionIdOptions): Promise<any>
+  delegateResource(
+    ownerAddress: string,
+    receiverAddress: string,
+    balance: BigNumber,
+    resource: TronStakeType,
+    lock: boolean,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Undoes a previous resource delegation from one account to another.
@@ -342,7 +393,14 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the undelegation is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/undelegateresource
    */
-  unDelegateResource(ownerAddress: string, receiverAddress: string, balance: BigNumber, resource: TronStakeType, lock: boolean, options?: VisibleAndPermissionIdOptions): Promise<any>
+  unDelegateResource(
+    ownerAddress: string,
+    receiverAddress: string,
+    balance: BigNumber,
+    resource: TronStakeType,
+    lock: boolean,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Withdraws the expired unfrozen balance for an account.
@@ -352,7 +410,10 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves when the withdrawal is complete.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/withdrawexpireunfreeze
    */
-  withdrawExpireUnfreeze(ownerAddress: string, options?: VisibleAndPermissionIdOptions): Promise<any>
+  withdrawExpireUnfreeze(
+    ownerAddress: string,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Fetches the available unfreeze count for a given account.
@@ -362,7 +423,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the available unfreeze count.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getavailableunfreezecount
    */
-  getAvailableUnfreezeCount(ownerAddress: string, options?: VisibleOption): Promise<any>
+  getAvailableUnfreezeCount(ownerAddress: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches the maximum withdrawable unfreeze amount for a given account.
@@ -372,7 +433,10 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the maximum withdrawable unfreeze amount.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getcanwithdrawunfreezeamount
    */
-  getCanWithdrawUnfreezeAmount(ownerAddress: string, options?: GetCanWithdrawUnfreezeAmountOptions): Promise<any>
+  getCanWithdrawUnfreezeAmount(
+    ownerAddress: string,
+    options?: GetCanWithdrawUnfreezeAmountOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Fetches the maximum size of delegatable resource for a given account.
@@ -383,7 +447,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the maximum delegatable resource size.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getcandelegatedmaxsize
    */
-  getCanDelegatedMaxSize(ownerAddress: string, type: TronStakeTypeNumeric, options?: VisibleOption): Promise<any>
+  getCanDelegatedMaxSize(
+    ownerAddress: string,
+    type: TronStakeTypeNumeric,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Fetches the delegated resource from a specified address to another, version 2.
@@ -394,7 +462,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the delegated resources.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getdelegatedresourcev2
    */
-  getDelegatedResourceV2(fromAddress: string, toAddress: string, options?: VisibleOption): Promise<any>
+  getDelegatedResourceV2(
+    fromAddress: string,
+    toAddress: string,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Fetches the account index of the delegated resource, version 2.
@@ -404,7 +476,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the account index of the delegated resource.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-account-resource-methods/getdelegatedresourceaccountindexv2
    */
-  getDelegatedResourceAccountIndexV2(value: string, options?: VisibleOption): Promise<any>
+  getDelegatedResourceAccountIndexV2(value: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches a block from the blockchain using either its ID or number.
@@ -414,7 +486,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the requested block.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getblock
    */
-  getBlock(idOrNum: string, options?: DetailOption): Promise<any>
+  getBlock(idOrNum: string, options?: DetailOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches a block from the blockchain using its number.
@@ -423,7 +495,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the requested block.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getblockbynum
    */
-  getBlockByNum(num: number): Promise<any>
+  getBlockByNum(num: number): Promise<ResponseDto<any>>
 
   /**
    * Fetches a block from the blockchain using its ID.
@@ -432,7 +504,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the requested block.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getblockbyid
    */
-  getBlockById(id: string): Promise<any>
+  getBlockById(id: string): Promise<ResponseDto<any>>
 
   /**
    * Fetches the latest block from the blockchain based on the number.
@@ -441,7 +513,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the requested block.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getblockbylatestnum
    */
-  getBlockByLatestNum(num: number): Promise<any>
+  getBlockByLatestNum(num: number): Promise<ResponseDto<any>>
 
   /**
    * Fetches a series of blocks from the blockchain using start and end numbers.
@@ -451,7 +523,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the requested series of blocks.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getblockbylimitnext
    */
-  getBlockByLimitNext(startNum: number, endNum: number): Promise<any>
+  getBlockByLimitNext(startNum: number, endNum: number): Promise<ResponseDto<any>>
 
   /**
    * Fetches the current block from the blockchain.
@@ -459,7 +531,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the current block.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getnowblock
    */
-  getNowBlock(): Promise<any>
+  getNowBlock(): Promise<ResponseDto<any>>
 
   /**
    * Fetches a transaction from the blockchain using its ID.
@@ -469,7 +541,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the requested transaction.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/gettransactionbyid
    */
-  getTransactionById(value: string, options?: VisibleOption): Promise<any>
+  getTransactionById(value: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches transaction info from the blockchain using the transaction ID.
@@ -478,7 +550,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the transaction info.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/gettransactioninfobyid
    */
-  getTransactionInfoById(value: string): Promise<any>
+  getTransactionInfoById(value: string): Promise<ResponseDto<any>>
 
   /**
    * Fetches transaction info from the blockchain by the block number.
@@ -487,7 +559,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the transaction info.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/gettransactioninfobyblocknum
    */
-  getTransactionInfoByBlockNum(num: number): Promise<any>
+  getTransactionInfoByBlockNum(num: number): Promise<ResponseDto<any>>
 
   /**
    * Lists all nodes of the network.
@@ -495,7 +567,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the list of nodes.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/listnodes
    */
-  listNodes(): Promise<any>
+  listNodes(): Promise<ResponseDto<any>>
 
   /**
    * Fetches information about the current node.
@@ -503,7 +575,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the node information.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getnodeinfo
    */
-  getNodeInfo(): Promise<any>
+  getNodeInfo(): Promise<ResponseDto<any>>
 
   /**
    * Fetches the chain parameters.
@@ -511,7 +583,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the chain parameters.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getchainparameters
    */
-  getChainParameters(): Promise<any>
+  getChainParameters(): Promise<ResponseDto<any>>
 
   /**
    * Fetches the balance of a block.
@@ -522,7 +594,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the block balance.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getblockbalance
    */
-  getBlockBalance(hash: string, number: BigNumber, options?: VisibleOption): Promise<any>
+  getBlockBalance(hash: string, number: BigNumber, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches the energy prices.
@@ -530,7 +602,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<TronPrices>} - Returns a Promise that resolves with the energy prices.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getenergyprices
    */
-  getEnergyPrices(): Promise<TronPrices>
+  getEnergyPrices(): Promise<ResponseDto<TronPrices>>
 
   /**
    * Fetches the bandwidth prices.
@@ -538,7 +610,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<TronPrices>} - Returns a Promise that resolves with the bandwidth prices.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getbandwidthprices
    */
-  getBandwidthPrices(): Promise<TronPrices>
+  getBandwidthPrices(): Promise<ResponseDto<TronPrices>>
 
   /**
    * Fetches the amount of TRX burned.
@@ -546,7 +618,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the amount of TRX burned.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-query-the-network-methods/getburntrx
    */
-  getBurnTRX(): Promise<any>
+  getBurnTRX(): Promise<ResponseDto<any>>
 
   /**
    * Fetches the asset issue by an account.
@@ -556,7 +628,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the asset issue.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/getassetissuebyaccount
    */
-  getAssetIssueByAccount(address: string, options?: VisibleOption): Promise<any>
+  getAssetIssueByAccount(address: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches the asset issue by its ID.
@@ -565,7 +637,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the asset issue.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/getassetissuebyid
    */
-  getAssetIssueById(value: number): Promise<any>
+  getAssetIssueById(value: number): Promise<ResponseDto<any>>
 
   /**
    * Fetches the asset issue by its name.
@@ -574,7 +646,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the asset issue.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/getassetissuebyname
    */
-  getAssetIssueByName(name: string): Promise<any>
+  getAssetIssueByName(name: string): Promise<ResponseDto<any>>
 
   /**
    * Fetches a list of all asset issues.
@@ -582,7 +654,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with a list of all asset issues.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/getassetissuelist
    */
-  getAssetIssueList(): Promise<any>
+  getAssetIssueList(): Promise<ResponseDto<any>>
 
   /**
    * Fetches a list of all asset issues by name.
@@ -591,7 +663,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with a list of all asset issues by name.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/getassetissuelistbyname
    */
-  getAssetIssueListByName(value: string): Promise<any>
+  getAssetIssueListByName(value: string): Promise<ResponseDto<any>>
 
   /**
    * Fetches a paginated list of all asset issues.
@@ -601,7 +673,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with a paginated list of all asset issues.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/getpaginatedassetissuelist
    */
-  getPaginatedAssetIssueList(offset: number, limit: number): Promise<any>
+  getPaginatedAssetIssueList(offset: number, limit: number): Promise<ResponseDto<any>>
 
   /**
    * Transfer an asset.
@@ -614,7 +686,13 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the asset transfer.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/transferasset
    */
-  transferAsset(ownerAddress: string, toAddress: string, assetName: string, amount: BigNumber, options?: TransferAssetIssueByAccountOptions): Promise<any>
+  transferAsset(
+    ownerAddress: string,
+    toAddress: string,
+    assetName: string,
+    amount: BigNumber,
+    options?: TransferAssetIssueByAccountOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Creates an asset issue.
@@ -632,7 +710,18 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the asset creation.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/createassetissue
    */
-  createAssetIssue(ownerAddress: string, name: string, abbr: string, totalSupply: number, trxNum: number, num: number, startTime: number, endTime: number, url: string, options?: CreateAssetIssueOptions): Promise<any>
+  createAssetIssue(
+    ownerAddress: string,
+    name: string,
+    abbr: string,
+    totalSupply: number,
+    trxNum: number,
+    num: number,
+    startTime: number,
+    endTime: number,
+    url: string,
+    options?: CreateAssetIssueOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Participate in an asset issue.
@@ -645,7 +734,13 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the participation.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/participateassetissue
    */
-  participateAssetIssue(toAddress: string, ownerAddress: string, assetName: string, amount: BigNumber, options?: VisibleOption): Promise<any>
+  participateAssetIssue(
+    toAddress: string,
+    ownerAddress: string,
+    assetName: string,
+    amount: BigNumber,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Unfreezes an asset.
@@ -655,7 +750,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the unfreeze operation.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/unfreezeasset
    */
-  unfreezeAsset(ownerAddress: string, options?: VisibleAndPermissionIdOptions): Promise<any>
+  unfreezeAsset(ownerAddress: string, options?: VisibleAndPermissionIdOptions): Promise<ResponseDto<any>>
 
   /**
    * Updates an asset.
@@ -666,7 +761,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the update operation.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-trc10-token-methods/updateasset
    */
-  updateAsset(ownerAddress: string, url: string, options?: UpdateAssetOptions): Promise<any>
+  updateAsset(ownerAddress: string, url: string, options?: UpdateAssetOptions): Promise<ResponseDto<any>>
 
   /**
    * Fetches contract information.
@@ -676,7 +771,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the contract information.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/getcontract
    */
-  getContract(value: string, options?: VisibleOption): Promise<any>
+  getContract(value: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Fetches contract information.
@@ -686,7 +781,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the contract information.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/getcontractinfo
    */
-  getContractInfo(value: string, options?: VisibleOption): Promise<any>
+  getContractInfo(value: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Triggers a smart contract.
@@ -699,7 +794,13 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of triggering the smart contract.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/triggersmartcontract
    */
-  triggerSmartContract(ownerAddress: string, contractAddress: string, functionSelector: string, parameter: string, options?: TriggerSmartContractOptions): Promise<any>
+  triggerSmartContract(
+    ownerAddress: string,
+    contractAddress: string,
+    functionSelector: string,
+    parameter: string,
+    options?: TriggerSmartContractOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Triggers a constant contract.
@@ -712,7 +813,13 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of triggering the constant contract.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/triggerconstantcontract
    */
-  triggerConstantContract(ownerAddress: string, contractAddress: string, functionSelector: string, parameter: string, options?: TriggerConstantContractOptions): Promise<any>
+  triggerConstantContract(
+    ownerAddress: string,
+    contractAddress: string,
+    functionSelector: string,
+    parameter: string,
+    options?: TriggerConstantContractOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Deploys a contract.
@@ -730,8 +837,8 @@ export interface TronRpcSuite extends AbstractRpcInterface {
     bytecode: string,
     ownerAddress: string,
     name: string,
-    options?: DeployContractOptions
-  ): Promise<any>
+    options?: DeployContractOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Updates the setting of a contract.
@@ -743,7 +850,12 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the setting update.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/updatesetting
    */
-  updateSetting(ownerAddress: string, contractAddress: string, consumeUserResourcePercent: number, options?: VisibleAndPermissionIdOptions): Promise<any>
+  updateSetting(
+    ownerAddress: string,
+    contractAddress: string,
+    consumeUserResourcePercent: number,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Updates the energy limit of a contract.
@@ -755,7 +867,12 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the energy limit update.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/updateenergylimit
    */
-  updateEnergyLimit(ownerAddress: string, contractAddress: string, originEnergyLimit: number, options?: VisibleAndPermissionIdOptions): Promise<any>
+  updateEnergyLimit(
+    ownerAddress: string,
+    contractAddress: string,
+    originEnergyLimit: number,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Clears the ABI of a contract.
@@ -766,7 +883,7 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the result of the ABI clear operation.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/clearabi
    */
-  clearAbi(ownerAddress: string, contractAddress: string, options?: VisibleOption): Promise<any>
+  clearAbi(ownerAddress: string, contractAddress: string, options?: VisibleOption): Promise<ResponseDto<any>>
 
   /**
    * Estimates the energy consumption of a contract call.
@@ -779,5 +896,11 @@ export interface TronRpcSuite extends AbstractRpcInterface {
    * @returns {Promise<any>} - Returns a Promise that resolves with the estimated energy consumption.
    * https://docs.tatum.com/docs/rpc-api-reference/tron-rpc-documentation/api-calls-for-smart-contract-methods/estimateenergy
    */
-  estimateEnergy(ownerAddress: string, contractAddress: string, functionSelector: string, parameter: string, options?: VisibleOption): Promise<any>
+  estimateEnergy(
+    ownerAddress: string,
+    contractAddress: string,
+    functionSelector: string,
+    parameter: string,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>>
 }

--- a/src/dto/rpc/UtxoBasedRpcSuite.ts
+++ b/src/dto/rpc/UtxoBasedRpcSuite.ts
@@ -1,37 +1,46 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ResponseDto } from '../../util'
 import { AbstractRpcInterface } from './AbstractJsonRpcInterface'
 
 export interface UtxoBasedRpcSuite extends UtxoBasedRpcInterface, AbstractRpcInterface {}
 
 export interface UtxoBasedRpcInterface {
   // blockchain methods
-  getBestBlockHash(): Promise<string>
-  getBlock(hashOrHeight: string, verbose?: 0 | 1 | 2): Promise<any>
-  getBlockChainInfo(): Promise<any>
-  getBlockCount(): Promise<number>
-  getBlockHash(height: number): Promise<string>
-  getBlockHeader(hash: string, verbose?: boolean): Promise<any>
-  getBlockStats(hash: string): Promise<any>
-  getChainTips(): Promise<any>
-  getDifficulty(): Promise<number>
-  getMempoolAncestors(txId: string, verbose?: boolean): Promise<any>
-  getMempoolDescendants(txId: string, verbose?: boolean): Promise<any>
-  getMempoolEntry(txId: string): Promise<any>
-  getMempoolInfo(): Promise<any>
-  getRawMemPool(verbose?: boolean): Promise<any>
-  getTxOut(txId: string, index: number, includeMempool?: boolean): Promise<any>
-  getTxOutProof(txIds: string[], blockhash?: string): Promise<any>
-  verifyTxOutProof(proof: string): Promise<any>
+  getBestBlockHash(): Promise<ResponseDto<string>>
+  getBlock(hashOrHeight: string, verbose?: 0 | 1 | 2): Promise<ResponseDto<any>>
+  getBlockChainInfo(): Promise<ResponseDto<any>>
+  getBlockCount(): Promise<ResponseDto<number>>
+  getBlockHash(height: number): Promise<ResponseDto<string>>
+  getBlockHeader(hash: string, verbose?: boolean): Promise<ResponseDto<any>>
+  getBlockStats(hash: string): Promise<ResponseDto<any>>
+  getChainTips(): Promise<ResponseDto<any>>
+  getDifficulty(): Promise<ResponseDto<number>>
+  getMempoolAncestors(txId: string, verbose?: boolean): Promise<ResponseDto<any>>
+  getMempoolDescendants(txId: string, verbose?: boolean): Promise<ResponseDto<any>>
+  getMempoolEntry(txId: string): Promise<ResponseDto<any>>
+  getMempoolInfo(): Promise<ResponseDto<any>>
+  getRawMemPool(verbose?: boolean): Promise<ResponseDto<any>>
+  getTxOut(txId: string, index: number, includeMempool?: boolean): Promise<ResponseDto<any>>
+  getTxOutProof(txIds: string[], blockhash?: string): Promise<ResponseDto<any>>
+  verifyTxOutProof(proof: string): Promise<ResponseDto<any>>
 
   // raw transactions methods
-  createRawTransaction(inputs: any[], outputs: any, locktime?: number, replaceable?: boolean): Promise<string>
-  decodeRawTransaction(hexstring: string): Promise<any>
-  decodeScript(hexstring: string): Promise<any>
-  getRawTransaction(txId: string, verbose?: boolean): Promise<any>
-  sendRawTransaction(hexstring: string): Promise<string>
+  createRawTransaction(
+    inputs: any[],
+    outputs: any,
+    locktime?: number,
+    replaceable?: boolean,
+  ): Promise<ResponseDto<string>>
+  decodeRawTransaction(hexstring: string): Promise<ResponseDto<any>>
+  decodeScript(hexstring: string): Promise<ResponseDto<any>>
+  getRawTransaction(txId: string, verbose?: boolean): Promise<ResponseDto<any>>
+  sendRawTransaction(hexstring: string): Promise<ResponseDto<string>>
 
   // utility methods
-  estimateSmartFee(blocks: number, estimateMode?: 'UNSET' | 'ECONOMICAL' | 'CONSERVATIVE'): Promise<any>
-  validateAddress(address: string): Promise<any>
-  verifyMessage(address: string, signature: string, message: string): Promise<boolean>
+  estimateSmartFee(
+    blocks: number,
+    estimateMode?: 'UNSET' | 'ECONOMICAL' | 'CONSERVATIVE',
+  ): Promise<ResponseDto<any>>
+  validateAddress(address: string): Promise<ResponseDto<any>>
+  verifyMessage(address: string, signature: string, message: string): Promise<ResponseDto<boolean>>
 }

--- a/src/dto/rpc/XrpRpcSuite.ts
+++ b/src/dto/rpc/XrpRpcSuite.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { ResponseDto } from '../../util'
 import { AbstractRpcInterface } from './AbstractJsonRpcInterface'
 
 /**
@@ -237,14 +238,6 @@ export type RipplePathFindOptions = Ledger & {
   sourceCurrencies?: Currency[]
 }
 
-export interface XrpResult {
-  // success indicates the request was successfully received and understood by the server
-  status: string
-
-  // response data received by the server
-  [key: string]: any
-}
-
 export interface XrpRpcSuite extends AbstractRpcInterface {
   // account methods
 
@@ -254,7 +247,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_channels
    */
-  accountChannels(account: string, options?: AccountChannelsOptions): Promise<XrpResult>
+  accountChannels(account: string, options?: AccountChannelsOptions): Promise<ResponseDto<any>>
 
   /**
    * Retrieves currencies of a given account.
@@ -262,7 +255,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_currencies
    */
-  accountCurrencies(account: string, options?: Ledger & StrictOption): Promise<XrpResult>
+  accountCurrencies(account: string, options?: Ledger & StrictOption): Promise<ResponseDto<any>>
 
   /**
    * Retrieves information about a given account.
@@ -270,7 +263,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_info
    */
-  accountInfo(account: string, options?: AccountInfoOptions): Promise<XrpResult>
+  accountInfo(account: string, options?: AccountInfoOptions): Promise<ResponseDto<any>>
 
   /**
    * Retrieves trust lines connected to an account.
@@ -278,7 +271,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_lines
    */
-  accountLines(account: string, options?: AccountLinesOptions): Promise<XrpResult>
+  accountLines(account: string, options?: AccountLinesOptions): Promise<ResponseDto<any>>
 
   /**
    * Retrieves non-fungible tokens (NFTs) owned by an account.
@@ -286,7 +279,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_nfts
    */
-  accountNfts(account: string, options?: Ledger & Pagination): Promise<XrpResult>
+  accountNfts(account: string, options?: Ledger & Pagination): Promise<ResponseDto<any>>
 
   /**
    * Retrieves the objects owned by an account on the ledger.
@@ -294,7 +287,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_objects
    */
-  accountObjects(account: string, options?: AccountObjectsOptions): Promise<XrpResult>
+  accountObjects(account: string, options?: AccountObjectsOptions): Promise<ResponseDto<any>>
 
   /**
    * Retrieves outstanding offers by a given account.
@@ -302,7 +295,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_offers
    */
-  accountOffers(account: string, options?: Ledger & Pagination & StrictOption): Promise<XrpResult>
+  accountOffers(account: string, options?: Ledger & Pagination & StrictOption): Promise<ResponseDto<any>>
 
   /**
    * Retrieves a list of transactions affecting an account.
@@ -310,7 +303,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/account_tx
    */
-  accountTx(account: string, options?: AccountTxOptions): Promise<XrpResult>
+  accountTx(account: string, options?: AccountTxOptions): Promise<ResponseDto<any>>
 
   /**
    * Calculates the total balances issued by an account.
@@ -318,7 +311,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/gateway_balances
    */
-  gatewayBalances(account: string, options?: GatewayBalancesOptions): Promise<XrpResult>
+  gatewayBalances(account: string, options?: GatewayBalancesOptions): Promise<ResponseDto<any>>
 
   /**
    * Checks potential issues with an account's NoRipple settings.
@@ -327,7 +320,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-account-methods/noripple_check
    */
-  norippleCheck(account: string, role: Role, options?: NorippleCheckOptions): Promise<XrpResult>
+  norippleCheck(account: string, role: Role, options?: NorippleCheckOptions): Promise<ResponseDto<any>>
 
   // ledger methods
 
@@ -336,33 +329,33 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-ledger-methods/ledger
    */
-  ledger(options?: LedgerOptions): Promise<XrpResult>
+  ledger(options?: LedgerOptions): Promise<ResponseDto<any>>
 
   /**
    * Retrieves information about the most recently closed ledger.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-ledger-methods/ledger_closed
    */
-  ledgerClosed(): Promise<XrpResult>
+  ledgerClosed(): Promise<ResponseDto<any>>
 
   /**
    * Retrieves information about the current in-progress ledger.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-ledger-methods/ledger_current
    */
-  ledgerCurrent(): Promise<XrpResult>
+  ledgerCurrent(): Promise<ResponseDto<any>>
 
   /**
    * Retrieves information about the contents of a ledger.
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-ledger-methods/ledger_data
    */
-  ledgerData(options?: Ledger & LedgerBinaryOption & Pagination & TypeOption): Promise<XrpResult>
+  ledgerData(options?: Ledger & LedgerBinaryOption & Pagination & TypeOption): Promise<ResponseDto<any>>
 
   /**
    * Retrieves a specific object from a ledger.
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-ledger-methods/ledger_entry
    */
-  ledgerEntry(options?: LedgerEntryOptions): Promise<XrpResult>
+  ledgerEntry(options?: LedgerEntryOptions): Promise<ResponseDto<any>>
 
   // transaction methods
 
@@ -372,7 +365,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-transaction-methods/submit
    */
-  submit(tx: Transaction, options?: Secrets & FailOption & AutoFilling): Promise<XrpResult>
+  submit(tx: Transaction, options?: Secrets & FailOption & AutoFilling): Promise<ResponseDto<any>>
 
   /**
    * Submits a multi-signed transaction to the XRP Ledger.
@@ -380,7 +373,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-transaction-methods/submit_multisigned
    */
-  submitMultisigned(txJson: TxJson, options?: FailOption): Promise<XrpResult>
+  submitMultisigned(txJson: TxJson, options?: FailOption): Promise<ResponseDto<any>>
 
   /**
    * Retrieves information about a particular transaction by its hash.
@@ -388,7 +381,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-transaction-methods/transaction_entry
    */
-  transactionEntry(txHash: string, options?: Ledger): Promise<XrpResult>
+  transactionEntry(txHash: string, options?: Ledger): Promise<ResponseDto<any>>
 
   /**
    * Retrieves information about a particular transaction by its ID.
@@ -396,14 +389,14 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-transaction-methods/tx
    */
-  tx(transaction: string, options?: TxOptions): Promise<XrpResult>
+  tx(transaction: string, options?: TxOptions): Promise<ResponseDto<any>>
 
   /**
    * Retrieves historical transactions.
    * @param start - The starting point for history retrieval.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-transaction-methods/tx_history
    */
-  txHistory(start: number): Promise<XrpResult>
+  txHistory(start: number): Promise<ResponseDto<any>>
 
   /**
    * Signs a transaction in preparation for submission to the XRP Ledger.
@@ -411,7 +404,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-transaction-methods/sign
    */
-  sign(txJson: TxJson, options?: Secrets & AutoFilling): Promise<XrpResult>
+  sign(txJson: TxJson, options?: Secrets & AutoFilling): Promise<ResponseDto<any>>
 
   /**
    * Signs a transaction for a specific account.
@@ -420,7 +413,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Secrets for signing the transaction.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-transaction-methods/sign_for
    */
-  signFor(account: string, txJson: TxJson, options?: Secrets): Promise<XrpResult>
+  signFor(account: string, txJson: TxJson, options?: Secrets): Promise<ResponseDto<any>>
 
   // path and order book methods
 
@@ -431,7 +424,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-path-and-order-book-methods/book_offers
    */
-  bookOffers(takerGets: Currency, takerPays: Currency, options?: BookOffersOptions): Promise<XrpResult>
+  bookOffers(takerGets: Currency, takerPays: Currency, options?: BookOffersOptions): Promise<ResponseDto<any>>
 
   /**
    * Checks if a deposit is authorized between two accounts.
@@ -440,7 +433,11 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-path-and-order-book-methods/deposit_authorized
    */
-  depositAuthorized(sourceAccount: string, destinationAccount: string, options?: Ledger): Promise<XrpResult>
+  depositAuthorized(
+    sourceAccount: string,
+    destinationAccount: string,
+    options?: Ledger,
+  ): Promise<ResponseDto<any>>
 
   /**
    * Retrieves buy offers for a specific NFT.
@@ -448,7 +445,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-path-and-order-book-methods/nft_buy_offers
    */
-  nftBuyOffers(nftId: string, options?: Ledger & Pagination): Promise<XrpResult>
+  nftBuyOffers(nftId: string, options?: Ledger & Pagination): Promise<ResponseDto<any>>
 
   /**
    * Retrieves sell offers for a specific NFT.
@@ -456,7 +453,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-path-and-order-book-methods/nft_sell_offers
    */
-  nftSellOffers(nftId: string, options?: Ledger & Pagination): Promise<XrpResult>
+  nftSellOffers(nftId: string, options?: Ledger & Pagination): Promise<ResponseDto<any>>
 
   /**
    * Finds the best path for a payment from the source account to the destination account for a specific amount.
@@ -471,7 +468,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
     destinationAccount: string,
     destinationAmount: CurrencyAmount,
     options?: RipplePathFindOptions,
-  ): Promise<XrpResult>
+  ): Promise<ResponseDto<any>>
 
   // payment channel methods
 
@@ -482,7 +479,7 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param options - Options for this request.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-payment-channel-methods/channel_authorize
    */
-  channelAuthorize(amount: string, channelId: string, options?: Secrets): Promise<XrpResult>
+  channelAuthorize(amount: string, channelId: string, options?: Secrets): Promise<ResponseDto<any>>
 
   /**
    * Verifies a signature against a specific amount and channel.
@@ -492,7 +489,12 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * @param signature - The signature to verify.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-payment-channel-methods/channel_verify
    */
-  channelVerify(amount: string, channelId: string, publicKey: string, signature: string): Promise<XrpResult>
+  channelVerify(
+    amount: string,
+    channelId: string,
+    publicKey: string,
+    signature: string,
+  ): Promise<ResponseDto<any>>
 
   // server info methods
 
@@ -500,26 +502,26 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * Retrieves information about current fee rates.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-server-info-methods/fee
    */
-  fee(): Promise<XrpResult>
+  fee(): Promise<ResponseDto<any>>
 
   /**
    * Retrieves information about the server.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-server-info-methods/server_info
    */
-  serverInfo(): Promise<XrpResult>
+  serverInfo(): Promise<ResponseDto<any>>
 
   /**
    * Retrieves the current state of the server.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-server-info-methods/server_state
    */
-  serverState(): Promise<XrpResult>
+  serverState(): Promise<ResponseDto<any>>
 
   /**
    * Retrieves the manifest of a specific public key.
    * @param publicKey - The public key for which the manifest is requested.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-server-info-methods/manifest
    */
-  manifest(publicKey: string): Promise<XrpResult>
+  manifest(publicKey: string): Promise<ResponseDto<any>>
 
   // utility methods
 
@@ -527,11 +529,11 @@ export interface XrpRpcSuite extends AbstractRpcInterface {
    * Sends a ping to the server.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-utility-methods/ping
    */
-  ping(): Promise<XrpResult>
+  ping(): Promise<ResponseDto<any>>
 
   /**
    * Generates a random number using server's random number generator.
    * https://docs.tatum.com/docs/rpc-api-reference/xrp-rpc-documentation/api-calls-for-utility-methods/random
    */
-  random(): Promise<XrpResult>
+  random(): Promise<ResponseDto<any>>
 }

--- a/src/e2e/rpc/evm.e2e.utils.ts
+++ b/src/e2e/rpc/evm.e2e.utils.ts
@@ -1,47 +1,58 @@
 import { Network } from '../../dto'
 import { BaseEvmClass, TatumSDK } from '../../service'
+import { Status } from '../../util'
 import { RpcE2eUtils } from './rpc.e2e.utils'
 
 export const EvmE2eUtils = {
   initTatum: async (network: Network) => TatumSDK.init<BaseEvmClass>(RpcE2eUtils.initConfig(network)),
-  e2e: ({ network, chainId }: { network: Network, chainId: number }) => {
+  e2e: ({ network, chainId }: { network: Network; chainId: number }) => {
     it('chain info', async () => {
       const tatum = await EvmE2eUtils.initTatum(network)
-      const info = await tatum.rpc.blockNumber()
-      expect(info.toNumber()).toBeGreaterThan(0)
+      const { data, status } = await tatum.rpc.blockNumber()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.toNumber()).toBeGreaterThan(0)
       tatum.rpc.destroy()
     })
 
     it('chain id', async () => {
       const tatum = await EvmE2eUtils.initTatum(network)
-      const info = await tatum.rpc.chainId()
-      expect(info.toNumber()).toBe(chainId)
+      const { data, status } = await tatum.rpc.chainId()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.toNumber()).toBe(chainId)
       tatum.rpc.destroy()
     })
 
     it('estimate gas', async () => {
       const tatum = await EvmE2eUtils.initTatum(network)
-      const info = await tatum.rpc.estimateGas({
+      const { data, status } = await tatum.rpc.estimateGas({
         from: '0xb4c9E4617a16Be36B92689b9e07e9F64757c1792',
         to: '0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263',
         value: '0x0',
       })
-      expect(info.toNumber()).toBeGreaterThan(0)
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.toNumber()).toBeGreaterThan(0)
       tatum.rpc.destroy()
     })
 
     it('gas price', async () => {
       const tatum = await EvmE2eUtils.initTatum(network)
-      const gasPrice = await tatum.rpc.gasPrice()
-      expect(gasPrice.toNumber()).toBeGreaterThan(0)
+      const { data, status } = await tatum.rpc.gasPrice()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.toNumber()).toBeGreaterThan(0)
       tatum.rpc.destroy()
     })
 
     it('client version', async () => {
       const tatum = await EvmE2eUtils.initTatum(network)
-      const clientVersion = await tatum.rpc.clientVersion()
-      expect(clientVersion).toBeTruthy()
+      const { data, status } = await tatum.rpc.clientVersion()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeTruthy()
       tatum.rpc.destroy()
     })
-  }
+  },
 }

--- a/src/e2e/rpc/tatum.rpc.flare.spec.ts
+++ b/src/e2e/rpc/tatum.rpc.flare.spec.ts
@@ -1,7 +1,8 @@
 import { Network } from '../../service'
 import { EvmE2eUtils } from './evm.e2e.utils'
 
-describe('Flare', () => {
+//temporarily skipping Flare as RPC's are not available
+describe.skip('Flare', () => {
   describe('mainnet', () => {
     EvmE2eUtils.e2e({ network: Network.FLARE, chainId: 14 })
   })

--- a/src/e2e/rpc/tatum.rpc.solana.spec.ts
+++ b/src/e2e/rpc/tatum.rpc.solana.spec.ts
@@ -1,5 +1,6 @@
 import { Commitment, Encoding } from '../../dto'
 import { Network, Solana, TatumSDK } from '../../service'
+import { Status } from '../../util'
 
 const getClient = async (testnet?: boolean): Promise<Solana> =>
   await TatumSDK.init<Solana>({
@@ -8,19 +9,18 @@ const getClient = async (testnet?: boolean): Promise<Solana> =>
     retryDelay: 2000,
   })
 
-const blockNumber = 197320164
+const blockNumber = 203046000
 
-// TODO: Once is Solana working remove
-describe.skip('Solana mainnet RPC', () => {
+describe('Solana mainnet RPC', () => {
   describe('getAccountInfo', () => {
     it('should return account info', async () => {
       const tatum = await getClient()
       const publicKey = '8Ew6iQXcTRHAUNNu3X9VBn1g1bJkXEZJ9gFD2AGKtdPB'
-      const result = await tatum.rpc.getAccountInfo(publicKey)
+      const { data, status } = await tatum.rpc.getAccountInfo(publicKey)
 
-      expect(result.context.slot).toBeGreaterThan(0)
-
-      expect(result.value?.lamports).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.context.slot).toBeGreaterThan(0)
+      expect(data.value?.lamports).toBeGreaterThan(0)
     })
   })
   describe('getBalance', () => {
@@ -28,70 +28,79 @@ describe.skip('Solana mainnet RPC', () => {
       const tatum = await getClient()
       const publicKey = '8Ew6iQXcTRHAUNNu3X9VBn1g1bJkXEZJ9gFD2AGKtdPB'
 
-      const balanceResponse = await tatum.rpc.getBalance(publicKey)
+      const { data, status } = await tatum.rpc.getBalance(publicKey)
 
-      const balance = balanceResponse.value
+      expect(status).toBe(Status.SUCCESS)
+
+      const balance = data.value
       expect(typeof balance).toBe('number')
       expect(balance).toBeGreaterThan(0)
 
-      expect(balanceResponse.context.slot).toBeGreaterThan(0)
+      expect(data.context.slot).toBeGreaterThan(0)
     })
 
     it('should return undefined if an invalid public key is provided', async () => {
       const tatum = await getClient()
       const publicKey = 'invalid-public-key'
 
-      const balanceResponse = await tatum.rpc.getBalance(publicKey)
+      const { error, status } = await tatum.rpc.getBalance(publicKey)
 
-      expect(balanceResponse).toBe(undefined)
+      expect(status).toBe(Status.ERROR)
+      expect(Array.isArray(error?.message)).toBe(true)
+      expect(error?.message[0]).toBe('Invalid param: Invalid')
     })
   })
 
   describe('getBlockHeight', () => {
     it('should return the current block height', async () => {
       const tatum = await getClient()
-      const blockHeightResponse = await tatum.rpc.getBlockHeight()
+      const { data, status } = await tatum.rpc.getBlockHeight()
 
-      expect(typeof blockHeightResponse).toBe('number')
-      expect(blockHeightResponse).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(typeof data).toBe('number')
+      expect(data).toBeGreaterThan(0)
     })
   })
 
   describe('getBlock', () => {
     it('should return a recent block', async () => {
       const tatum = await getClient()
-      const blockHeightResponse = await tatum.rpc.getSlot()
-      const blockResponse = await tatum.rpc.getBlock(blockHeightResponse, {
+      const { data: slot } = await tatum.rpc.getSlot()
+      const { data, status } = await tatum.rpc.getBlock(slot, {
         encoding: Encoding.JsonParsed,
         maxSupportedTransactionVersion: 0,
       })
-      expect(blockResponse).toHaveProperty('blockhash')
-      expect(blockResponse?.blockhash).toBeTruthy()
-      expect(blockResponse?.previousBlockhash).toBeTruthy()
-      expect(blockResponse?.blockHeight).toBeGreaterThan(0)
-      expect(blockResponse?.parentSlot).toBeGreaterThan(0)
-      expect(blockResponse?.blockTime).toBeGreaterThan(0)
-      expect(Array.isArray(blockResponse?.transactions)).toBe(true)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toHaveProperty('blockhash')
+      expect(data?.blockhash).toBeTruthy()
+      expect(data?.previousBlockhash).toBeTruthy()
+      expect(data?.blockHeight).toBeGreaterThan(0)
+      expect(data?.parentSlot).toBeGreaterThan(0)
+      expect(data?.blockTime).toBeGreaterThan(0)
+      expect(Array.isArray(data?.transactions)).toBe(true)
     })
   })
 
   describe('getBlockProduction', () => {
     it('should return block production information', async () => {
       const tatum = await getClient()
-      const blockProduction = await tatum.rpc.getBlockProduction()
+      const { data, status } = await tatum.rpc.getBlockProduction()
 
-      expect(blockProduction.context.slot).toBeGreaterThan(0)
-      expect(blockProduction).toHaveProperty('value.byIdentity')
-      expect(blockProduction).toHaveProperty('value.range.firstSlot')
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.context.slot).toBeGreaterThan(0)
+      expect(data).toHaveProperty('value.byIdentity')
+      expect(data).toHaveProperty('value.range.firstSlot')
     })
   })
 
   describe('getBlockCommitment', () => {
     it('should return block commitment information', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getBlockCommitment(blockNumber)
-      expect(result).toHaveProperty('commitment')
-      expect(result.totalStake).toBeGreaterThan(0)
+      const { data, status } = await tatum.rpc.getBlockCommitment(blockNumber)
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toHaveProperty('commitment')
+      expect(data.totalStake).toBeGreaterThan(0)
     })
   })
 
@@ -100,139 +109,156 @@ describe.skip('Solana mainnet RPC', () => {
       const tatum = await getClient()
       const startSlot = 193167060
       const endSlot = 193167070
-      const blocksResponse = await tatum.rpc.getBlocks(endSlot, startSlot)
+      const { data, status } = await tatum.rpc.getBlocks(endSlot, startSlot)
 
-      expect(Array.isArray(blocksResponse)).toBe(true)
+      expect(status).toBe(Status.SUCCESS)
+      expect(Array.isArray(data)).toBe(true)
     })
 
     // Sometimes this test fails, so we skip it for now
     it.skip('should return an array of block numbers between two slots, passing only endSlot', async () => {
       const tatum = await getClient()
-      const blocksResponse = await tatum.rpc.getBlocks(blockNumber)
-      console.log(blocksResponse)
-      expect(Array.isArray(blocksResponse)).toBe(true)
+      const { data, status } = await tatum.rpc.getBlocks(blockNumber)
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(Array.isArray(data)).toBe(true)
     }, 9000000)
 
     it('should return an array of confirmed block numbers between two slots', async () => {
       const tatum = await getClient()
       const startSlot = 193167060
       const endSlot = 193167070
-      const blocksResponse = await tatum.rpc.getBlocks(endSlot, startSlot, {
+      const { data, status } = await tatum.rpc.getBlocks(endSlot, startSlot, {
         commitment: Commitment.Confirmed,
       })
 
-      expect(Array.isArray(blocksResponse)).toBe(true)
+      expect(status).toBe(Status.SUCCESS)
+      expect(Array.isArray(data)).toBe(true)
     })
   })
 
   describe('getBlockTime', () => {
     it('should return block time ', async () => {
       const tatum = await getClient()
-      const blockHeightResponse = await tatum.rpc.getSlot()
-      const result = await tatum.rpc.getBlockTime(blockHeightResponse)
+      const { data: slot } = await tatum.rpc.getSlot()
+      const { data, status } = await tatum.rpc.getBlockTime(slot)
 
-      expect(typeof result).toBe('number')
-      expect(result).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(typeof data).toBe('number')
+      expect(data).toBeGreaterThan(0)
     })
   })
 
   describe('getClusterNodes', () => {
     it('should return cluster nodes info ', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getClusterNodes()
+      const { data, status } = await tatum.rpc.getClusterNodes()
 
-      expect(Array.isArray(result)).toBe(true)
+      expect(status).toBe(Status.SUCCESS)
+      expect(Array.isArray(data)).toBe(true)
     })
   })
 
   describe('getEpochInfo', () => {
     it('should return epoch info ', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getEpochInfo()
+      const { data, status } = await tatum.rpc.getEpochInfo()
 
-      expect(result.epoch).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.epoch).toBeGreaterThan(0)
     })
   })
 
   describe('getEpochSchedule', () => {
     it('should return epoch schedule ', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getEpochSchedule()
+      const { data, status } = await tatum.rpc.getEpochSchedule()
 
-      expect(result.slotsPerEpoch).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.slotsPerEpoch).toBeGreaterThan(0)
     })
   })
 
   describe('getFirstAvailableBlock', () => {
     it('should return first available block', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getFirstAvailableBlock()
+      const { data, status } = await tatum.rpc.getFirstAvailableBlock()
 
-      expect(result).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeGreaterThan(0)
     })
   })
 
   describe('getGenesisHash', () => {
     it('should return genesis hash', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getGenesisHash()
+      const { data, status } = await tatum.rpc.getGenesisHash()
 
-      expect(result).toBeTruthy()
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeTruthy()
     })
   })
 
   describe('getHealth', () => {
     it('should return health status', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getHealth()
+      const { data, status } = await tatum.rpc.getHealth()
 
-      expect(result).toEqual('ok')
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toEqual('ok')
     })
   })
 
   describe('getHighestSnapshotSlot', () => {
     it('should return highest snapshot slot', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getHighestSnapshotSlot()
+      const { data, status } = await tatum.rpc.getHighestSnapshotSlot()
 
-      expect(result.full).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.full).toBeGreaterThan(0)
     })
   })
 
   describe('getIdentity', () => {
     it('should return identity', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getIdentity()
+      const { data, status } = await tatum.rpc.getIdentity()
 
-      expect(result).toBeTruthy()
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeTruthy()
     })
   })
 
   describe('getInflationGovernor', () => {
     it('should return inflation governor info', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getInflationGovernor()
+      const { data, status } = await tatum.rpc.getInflationGovernor()
 
-      expect(result.terminal).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.terminal).toBeGreaterThan(0)
     })
   })
 
   describe('getInflationRate', () => {
     it('should return inflation rate', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getInflationRate()
+      const { data, status } = await tatum.rpc.getInflationRate()
 
-      expect(result.total).toBeGreaterThan(0)
-      expect(result.epoch).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.total).toBeGreaterThan(0)
+      expect(data.epoch).toBeGreaterThan(0)
     })
   })
 
   describe('getInflationReward', () => {
     it.skip('should return inflation reward', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getInflationReward(['GUP3BG93X9EoDor3bDarTqv8n653u1Bkr2NbQqRqBZwF'])
+      const { data, status } = await tatum.rpc.getInflationReward([
+        'GUP3BG93X9EoDor3bDarTqv8n653u1Bkr2NbQqRqBZwF',
+      ])
 
-      expect(result[0].epoch).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data[0].epoch).toBeGreaterThan(0)
     })
   })
 
@@ -240,30 +266,34 @@ describe.skip('Solana mainnet RPC', () => {
   describe('getLargestAccounts', () => {
     it.skip('should return largest accounts', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getLargestAccounts()
+      const { data, status } = await tatum.rpc.getLargestAccounts()
 
-      expect(result.context.slot).toBeGreaterThan(0)
-      expect(result.value.length).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.context.slot).toBeGreaterThan(0)
+      expect(data.value.length).toBeGreaterThan(0)
     })
   })
 
   describe('getLatestBlockhash', () => {
     it('should return latest blockhash', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getLatestBlockhash()
+      const { data, status } = await tatum.rpc.getLatestBlockhash()
 
-      expect(result.context.slot).toBeGreaterThan(0)
-      expect(result.value.blockhash).toBeTruthy()
-      expect(result.value.lastValidBlockHeight).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.context.slot).toBeGreaterThan(0)
+      expect(data.value.blockhash).toBeTruthy()
+      expect(data.value.lastValidBlockHeight).toBeGreaterThan(0)
     })
   })
 
   describe('getLeaderSchedule', () => {
     it('should return leader schedule', async () => {
       const tatum = await getClient()
-      const result = await tatum.rpc.getLeaderSchedule()
+      const { data, status } = await tatum.rpc.getLeaderSchedule()
+
+      expect(status).toBe(Status.SUCCESS)
       //binance validator
-      expect(result?.DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy.length).toBeGreaterThan(0)
+      expect(data?.DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy.length).toBeGreaterThan(0)
     })
   })
 
@@ -271,9 +301,12 @@ describe.skip('Solana mainnet RPC', () => {
     it('should return account info', async () => {
       const tatum = await getClient()
       //binance validator
-      const result = await tatum.rpc.getMultipleAccounts(['DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy'])
-      expect(result.context.slot).toBeGreaterThan(0)
-      expect(result.value[0]?.lamports).toBeGreaterThan(0)
+      const { data, status } = await tatum.rpc.getMultipleAccounts([
+        'DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy',
+      ])
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.context.slot).toBeGreaterThan(0)
+      expect(data.value[0]?.lamports).toBeGreaterThan(0)
     })
   })
 
@@ -281,8 +314,9 @@ describe.skip('Solana mainnet RPC', () => {
     it('should return slot number', async () => {
       const tatum = await getClient()
 
-      const result = await tatum.rpc.getSlot()
-      expect(result).toBeGreaterThan(0)
+      const { data, status } = await tatum.rpc.getSlot()
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeGreaterThan(0)
     })
   })
 
@@ -290,8 +324,9 @@ describe.skip('Solana mainnet RPC', () => {
     it('should return slot leader info', async () => {
       const tatum = await getClient()
 
-      const result = await tatum.rpc.getSlotLeader()
-      expect(result).toBeTruthy()
+      const { data, status } = await tatum.rpc.getSlotLeader()
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeTruthy()
     })
   })
 
@@ -299,9 +334,12 @@ describe.skip('Solana mainnet RPC', () => {
     it('should return token account balance', async () => {
       const tatum = await getClient()
 
-      const result = await tatum.rpc.getTokenAccountBalance('DhzDoryP2a4rMK2bcWwJxrE2uW6ir81ES8ZwJJPPpxDN')
-      expect(result.context.slot).toBeGreaterThan(0)
-      expect(result.value.amount).toBeTruthy()
+      const { data, status } = await tatum.rpc.getTokenAccountBalance(
+        'DhzDoryP2a4rMK2bcWwJxrE2uW6ir81ES8ZwJJPPpxDN',
+      )
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.context.slot).toBeGreaterThan(0)
+      expect(data.value.amount).toBeTruthy()
     })
   })
 
@@ -309,15 +347,16 @@ describe.skip('Solana mainnet RPC', () => {
     it('should return token accounts by owner', async () => {
       const tatum = await getClient()
 
-      const result = await tatum.rpc.getTokenAccountsByOwner(
+      const { data, status } = await tatum.rpc.getTokenAccountsByOwner(
         'GgPpTKg78vmzgDtP1DNn72CHAYjRdKY7AV6zgszoHCSa',
         {
           mint: '1YDQ35V8g68FGvcT85haHwAXv1U7XMzuc4mZeEXfrjE',
         },
         { encoding: Encoding.JsonParsed },
       )
-      expect(result.context.slot).toBeGreaterThan(0)
-      expect(result.value.length).toBeGreaterThan(0)
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.context.slot).toBeGreaterThan(0)
+      expect(data.value.length).toBeGreaterThan(0)
     })
   })
 
@@ -325,16 +364,19 @@ describe.skip('Solana mainnet RPC', () => {
     it('should return transaction data', async () => {
       const tatum = await getClient()
 
-      const blockHeightResponse = await tatum.rpc.getSlot()
-      const blockResponse = await tatum.rpc.getBlock(blockHeightResponse, {
+      const { data: slot } = await tatum.rpc.getSlot()
+      const { data: blockResponse } = await tatum.rpc.getBlock(slot, {
         encoding: Encoding.JsonParsed,
         maxSupportedTransactionVersion: 0,
       })
 
-      const result = await tatum.rpc.getTransaction(blockResponse?.transactions[0].transaction.signatures[0])
+      const { data, status } = await tatum.rpc.getTransaction(
+        blockResponse?.transactions[0].transaction.signatures[0],
+      )
 
-      expect(result?.slot).toBeGreaterThan(0)
-      expect(result?.transaction).toBeTruthy()
+      expect(status).toBe(Status.SUCCESS)
+      expect(data?.slot).toBeGreaterThan(0)
+      expect(data?.transaction).toBeTruthy()
     })
   })
 
@@ -343,14 +385,18 @@ describe.skip('Solana mainnet RPC', () => {
     it.skip('should return account data', async () => {
       const tatum = await getClient(true)
 
-      const result = await tatum.rpc.getProgramAccounts('FriELggez2Dy3phZeHHAdpcoEXkKQVkv6tx3zDtCVP8T', {
-        filters: [
-          {
-            dataSize: 165, // number of bytes
-          },
-        ],
-      })
-      expect(result).toBeTruthy()
+      const { data, status } = await tatum.rpc.getProgramAccounts(
+        'FriELggez2Dy3phZeHHAdpcoEXkKQVkv6tx3zDtCVP8T',
+        {
+          filters: [
+            {
+              dataSize: 165, // number of bytes
+            },
+          ],
+        },
+      )
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeTruthy()
     })
   })
 })

--- a/src/e2e/rpc/tatum.rpc.tron.spec.ts
+++ b/src/e2e/rpc/tatum.rpc.tron.spec.ts
@@ -1,5 +1,5 @@
 import { Network, TatumSDK, Tron } from '../../service'
-
+import { Status } from '../../util'
 
 const getTronRpc = async (testnet?: boolean) =>
   await TatumSDK.init<Tron>({
@@ -13,63 +13,73 @@ describe('RPCs', () => {
     describe('testnet', () => {
       it('getNowBlock', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getNowBlock()
-        expect(res.block_header.raw_data.number).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.getNowBlock()
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getChainParameters', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getChainParameters()
-        expect(res.chainParameter.length).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.getChainParameters()
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.chainParameter.length).toBeGreaterThan(0)
       })
       it('getBlockByNum', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getBlock('1000000')
-        expect(res.block_header.raw_data.number).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.getBlock('1000000')
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getBlockById', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getBlock(
+        const { data, status } = await tatum.rpc.getBlock(
           '00000000000f424013e51b18e0782a32fa079ddafdb2f4c343468cf8896dc887',
         )
-        expect(res.block_header.raw_data.number).toBeGreaterThan(0)
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getTransactionById', async () => {
         const tatum = await getTronRpc(true)
-        const res = await tatum.rpc.getTransactionById(
+        const { data, status } = await tatum.rpc.getTransactionById(
           '7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc',
         )
-        expect(res.txID).toBe('7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc')
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.txID).toBe('7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc')
       })
     })
     describe('mainnet', () => {
       it('getNowBlock', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getNowBlock()
-        expect(res.block_header.raw_data.number).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.getNowBlock()
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getChainParameters', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getChainParameters()
-        expect(res.chainParameter.length).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.getChainParameters()
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.chainParameter.length).toBeGreaterThan(0)
       })
       it('getBlockByNum', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getBlock('51173114')
-        expect(res.block_header.raw_data.number).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.getBlock('51173114')
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getBlockById', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getBlock(
+        const { data, status } = await tatum.rpc.getBlock(
           '00000000030cd6faf6c282df598285c51bd61e108f98e90ea8a0ef4bd0b2d9ec',
         )
-        expect(res.block_header.raw_data.number).toBeGreaterThan(0)
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.block_header.raw_data.number).toBeGreaterThan(0)
       })
       it('getTransactionById', async () => {
         const tatum = await getTronRpc(false)
-        const res = await tatum.rpc.getTransactionById(
+        const { data, status } = await tatum.rpc.getTransactionById(
           'eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598',
         )
-        expect(res.txID).toBe('eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598')
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.txID).toBe('eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598')
       })
     })
   })

--- a/src/e2e/rpc/tatum.rpc.xrp.spec.ts
+++ b/src/e2e/rpc/tatum.rpc.xrp.spec.ts
@@ -1,4 +1,5 @@
 import { Network, TatumSDK, Xrp } from '../../service'
+import { Status } from '../../util'
 
 const getXrpRpc = async (testnet?: boolean) =>
   await TatumSDK.init<Xrp>({
@@ -18,13 +19,17 @@ describe('RPCs', () => {
     describe('testnet', () => {
       it('ledger_current', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.ledgerCurrent()
-        expect(res.ledger_current_index).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.ledgerCurrent()
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.ledger_current_index).toBeGreaterThan(0)
       })
       it('ping', async () => {
         const tatum = await getXrpRpc(true)
-        const res = await tatum.rpc.ping()
-        expect(res.status).toBe('success')
+        const { data, status } = await tatum.rpc.ping()
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.status).toBe('success')
       })
     })
   })
@@ -32,11 +37,13 @@ describe('RPCs', () => {
     describe('mainnet', () => {
       it('account_channels', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.accountChannels('rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn', {
+        const { data, status } = await tatum.rpc.accountChannels('rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn', {
           destinationAccount: 'ra5nK24KXen9AHvsdFTKHSANinZseWnPcX',
           ledgerIndex: 'validated',
         })
-        expect(res.channels).toContainEqual({
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.channels).toContainEqual({
           account: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
           amount: '1000',
           balance: '0',
@@ -49,50 +56,64 @@ describe('RPCs', () => {
       })
       it('account_currencies', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.accountCurrencies('r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59', {
+        const { data, status } = await tatum.rpc.accountCurrencies('r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59', {
           ledgerIndex: 'validated',
           strict: true,
         })
-        expect(res.receive_currencies.length).toBeGreaterThan(0)
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.receive_currencies.length).toBeGreaterThan(0)
       })
       it('account_lines', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.accountLines('r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59')
-        expect(res.lines.length).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.accountLines('r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59')
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.lines.length).toBeGreaterThan(0)
       })
       it('account_info', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.accountInfo('rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn', {
+        const { data, status } = await tatum.rpc.accountInfo('rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn', {
           strict: true,
           ledgerIndex: 'current',
           queue: true,
         })
-        expect(res.account_data.Account).toBe('rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn')
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.account_data.Account).toBe('rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn')
       })
       // TODO: not working in pipeline
       it.skip('account_tx', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.accountTx('rLNaPoKeeBjZe2qs6x52yVPZpZ8td4dc6w', {
+        const { data, status } = await tatum.rpc.accountTx('rLNaPoKeeBjZe2qs6x52yVPZpZ8td4dc6w', {
           binary: false,
           forward: false,
           ledgerIndexMax: -1,
           ledgerIndexMin: -1,
           limit: 2,
         })
-        expect(res.transactions.length).toBeGreaterThan(0)
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.transactions.length).toBeGreaterThan(0)
       })
       it('noripple_check', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.norippleCheck('r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59', 'gateway', {
-          transactions: true,
-          limit: 2,
-          ledgerIndex: 'current',
-        })
-        expect(res.problems.length).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.norippleCheck(
+          'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59',
+          'gateway',
+          {
+            transactions: true,
+            limit: 2,
+            ledgerIndex: 'current',
+          },
+        )
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.problems.length).toBeGreaterThan(0)
       })
       it('ledger', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.ledger({
+        const { data, status } = await tatum.rpc.ledger({
           ledgerIndex: 'validated',
           accounts: false,
           full: false,
@@ -100,46 +121,61 @@ describe('RPCs', () => {
           expand: false,
           ownerFunds: false,
         })
-        expect(res.ledger.accepted).toBe(true)
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.ledger.accepted).toBe(true)
       })
       it('ledger_closed', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.ledgerClosed()
-        expect(res.ledger_index).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.ledgerClosed()
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.ledger_index).toBeGreaterThan(0)
       })
       it('ledger_entry', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.ledgerEntry({
+        const { data, status } = await tatum.rpc.ledgerEntry({
           index: '7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4',
           ledgerIndex: 'validated',
         })
-        expect(res.index).toBe('7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4')
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.index).toBe('7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4')
       })
       it('submit', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.submit(
+        const { data, status } = await tatum.rpc.submit(
           '1200002280000000240000001E61D4838D7EA4C6800000000000000000000000000055534400000000004B4E9C06F24296074F7BC48F92A97916C6DC5EA968400000000000000B732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB7447304502210095D23D8AF107DF50651F266259CC7139D0CD0C64ABBA3A958156352A0D95A21E02207FCF9B77D7510380E49FF250C21B57169E14E9B4ACFD314CEDC79DDD0A38B8A681144B4E9C06F24296074F7BC48F92A97916C6DC5EA983143E9D4A2B8AA0780F682D136F7A56D6724EF53754',
         )
-        expect(res.tx_json.Destination).toBe('ra5nK24KXen9AHvsdFTKHSANinZseWnPcX')
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.tx_json.Destination).toBe('ra5nK24KXen9AHvsdFTKHSANinZseWnPcX')
       })
       it('transaction_entry', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.transactionEntry(
+        const { data, status } = await tatum.rpc.transactionEntry(
           'C53ECF838647FA5A4C780377025FEC7999AB4182590510CA461444B207AB74A9',
           { ledgerIndex: 56865245 },
         )
-        expect(res.tx_json.TransactionType).toBe('OfferCreate')
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.tx_json.TransactionType).toBe('OfferCreate')
       })
       it('tx', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.tx('C53ECF838647FA5A4C780377025FEC7999AB4182590510CA461444B207AB74A9', {
-          binary: false,
-        })
-        expect(res.TransactionType).toBe('OfferCreate')
+        const { data, status } = await tatum.rpc.tx(
+          'C53ECF838647FA5A4C780377025FEC7999AB4182590510CA461444B207AB74A9',
+          {
+            binary: false,
+          },
+        )
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.TransactionType).toBe('OfferCreate')
       })
       it('book_offers', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.bookOffers(
+        const { data, status } = await tatum.rpc.bookOffers(
           {
             currency: 'XRP',
           },
@@ -149,12 +185,16 @@ describe('RPCs', () => {
           },
           { taker: 'r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59', limit: 10 },
         )
-        expect(res.offers.length).toBeGreaterThan(0)
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.offers.length).toBeGreaterThan(0)
       })
       it('fee', async () => {
         const tatum = await getXrpRpc()
-        const res = await tatum.rpc.fee()
-        expect(res.ledger_current_index).toBeGreaterThan(0)
+        const { data, status } = await tatum.rpc.fee()
+
+        expect(status).toBe(Status.SUCCESS)
+        expect(data.ledger_current_index).toBeGreaterThan(0)
       })
     })
   })

--- a/src/e2e/rpc/utxo.e2e.utils.ts
+++ b/src/e2e/rpc/utxo.e2e.utils.ts
@@ -1,5 +1,6 @@
 import { Network } from '../../dto'
 import { BaseUtxoClass, TatumSDK } from '../../service'
+import { Status } from '../../util'
 import { RpcE2eUtils } from './rpc.e2e.utils'
 
 interface TatumBtcUtils {
@@ -12,8 +13,10 @@ export const UtxoE2eUtils = {
   e2e: ({ type, network }: TatumBtcUtils) => {
     it('chain info', async () => {
       const tatum = await UtxoE2eUtils.initTatum(network)
-      const info = await tatum.rpc.getBlockChainInfo()
-      expect(info.chain).toBe(type)
+      const { data, status } = await tatum.rpc.getBlockChainInfo()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data.chain).toBe(type)
       tatum.rpc.destroy()
     })
 
@@ -29,31 +32,38 @@ export const UtxoE2eUtils = {
 
     it('best block hash', async () => {
       const tatum = await UtxoE2eUtils.initTatum(network)
-      const bestBlockHash = await tatum.rpc.getBestBlockHash()
-      expect(bestBlockHash).toBeTruthy()
+      const { data, status } = await tatum.rpc.getBestBlockHash()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeTruthy()
       tatum.rpc.destroy()
     })
 
     it('block count', async () => {
       const tatum = await UtxoE2eUtils.initTatum(network)
-      const blockCount = await tatum.rpc.getBlockCount()
-      expect(blockCount).toBeGreaterThan(0)
+      const { data, status } = await tatum.rpc.getBlockCount()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeGreaterThan(0)
       tatum.rpc.destroy()
     })
 
     it('difficulty', async () => {
       const tatum = await UtxoE2eUtils.initTatum(network)
-      const difficulty = await tatum.rpc.getDifficulty()
-      expect(difficulty).toBeGreaterThan(0)
+      const { data, status } = await tatum.rpc.getDifficulty()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeGreaterThan(0)
       tatum.rpc.destroy()
     })
 
     it('mempool info', async () => {
       const tatum = await UtxoE2eUtils.initTatum(network)
-      const mempoolInfo = await tatum.rpc.getMempoolInfo()
-      expect(mempoolInfo).toBeDefined()
+      const { data, status } = await tatum.rpc.getMempoolInfo()
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toBeDefined()
       tatum.rpc.destroy()
     })
-
   },
 }

--- a/src/e2e/tatum.fee.spec.ts
+++ b/src/e2e/tatum.fee.spec.ts
@@ -1,5 +1,6 @@
 import { ApiVersion, Network, TatumSDK } from '../service'
 import { Bitcoin, Ethereum } from '../service/tatum'
+import { Status } from '../util'
 
 describe('Fee', () => {
   it('should return fee for eth testnet', async () => {
@@ -10,8 +11,9 @@ describe('Fee', () => {
       version: ApiVersion.V1,
     })
 
-    const result = await tatum.fee.getCurrentFee()
-    expect(result.gasPrice.fast).toBeDefined()
+    const { data, status } = await tatum.fee.getCurrentFee()
+    expect(status).toBe(Status.SUCCESS)
+    expect(data.gasPrice.fast).toBeDefined()
   })
 
   it('should return fee for btc testnet', async () => {
@@ -22,7 +24,9 @@ describe('Fee', () => {
       version: ApiVersion.V1,
     })
 
-    const result = await tatum.fee.getCurrentFee()
-    expect(result.fast).toBeDefined()
+    const { data, status } = await tatum.fee.getCurrentFee()
+
+    expect(status).toBe(Status.SUCCESS)
+    expect(data.fast).toBeDefined()
   })
 })

--- a/src/e2e/tatum.token.spec.ts
+++ b/src/e2e/tatum.token.spec.ts
@@ -1,4 +1,5 @@
 import { Ethereum, Network, TatumSDK } from '../service'
+import { Status } from '../util'
 
 describe('Tatum token', () => {
   let tatum: Ethereum
@@ -269,10 +270,12 @@ describe('Tatum token', () => {
     })
 
     it('should get deployed sc address', async function () {
-      const address = await tatum.rpc.getContractAddress(
+      const { data, status } = await tatum.rpc.getContractAddress(
         '0x2b04f0d7ffbd3380c4deb4cb428f8562ebbc38ae4a377ad420ce9bf1508ea47d',
       )
-      expect(address).toStrictEqual('0x9b7d44c8d1f1f1bf42f596600c28431b567fcd40')
+
+      expect(status).toBe(Status.SUCCESS)
+      expect(data).toStrictEqual('0x9b7d44c8d1f1f1bf42f596600c28431b567fcd40')
     })
   })
 })

--- a/src/service/rpc/SolanaRpc.ts
+++ b/src/service/rpc/SolanaRpc.ts
@@ -44,8 +44,8 @@ import {
   SolanaVersion,
   SolanaVoteAccount,
 } from '../../dto'
+import { ResponseDto, ResponseUtils, Utils } from '../../util'
 import { AbstractBatchRpc } from './generic'
-import { Utils } from '../../util'
 
 @Service({
   factory: (data: { id: string }) => {
@@ -61,59 +61,65 @@ export class SolanaRpc extends AbstractBatchRpc implements SolanaRpcSuite {
   getAccountInfo(
     pubkey: string,
     options?: GetAccountInfoOptions,
-  ): Promise<SolanaTypeWithContext<SolanaAccountInfo | null>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaAccountInfo | null>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getAccountInfo', [pubkey, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  getBalance(address: string): Promise<SolanaTypeWithContext<number>> {
+  getBalance(address: string): Promise<ResponseDto<SolanaTypeWithContext<number>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getBalance', [address]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  getBlockHeight(options?: GetCommitmentMinContextSlotOptions): Promise<number> {
+  getBlockHeight(options?: GetCommitmentMinContextSlotOptions): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getBlockHeight', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
   getBlock(
     block: number,
     options?: GetBlockOptions,
-  ): Promise<{
-    blockhash: string
-    previousBlockhash: string
-    parentSlot: number
-    transactions: Array<any>
-    signatures: Array<any>
-    rewards: Array<any> | undefined
-    blockTime: number | null
-    blockHeight: number | null
-  } | null> {
+  ): Promise<
+    ResponseDto<{
+      blockhash: string
+      previousBlockhash: string
+      parentSlot: number
+      transactions: Array<any>
+      signatures: Array<any>
+      rewards: Array<any> | undefined
+      blockTime: number | null
+      blockHeight: number | null
+    } | null>
+  > {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getBlock', [block, options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
   getBlockProduction(
     options?: GetBlockProductionOptions,
-  ): Promise<SolanaTypeWithContext<SolanaBlockProduction>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaBlockProduction>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getBlockProduction', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  getBlockCommitment(block: number): Promise<{ commitment: Array<number>; totalStake: number }> {
+  getBlockCommitment(block: number): Promise<ResponseDto<{ commitment: Array<number>; totalStake: number }>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getBlockCommitment', [block]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getBlocks(endSlot: number, startSlot?: number, options?: GetCommitmentOptions): Promise<Array<number>> {
+  getBlocks(
+    endSlot: number,
+    startSlot?: number,
+    options?: GetCommitmentOptions,
+  ): Promise<ResponseDto<Array<number>>> {
     let params: any = [endSlot]
     if (startSlot) params = [startSlot, endSlot]
 
@@ -121,103 +127,114 @@ export class SolanaRpc extends AbstractBatchRpc implements SolanaRpcSuite {
 
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getBlocks', params))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getBlockTime(block: number): Promise<number | null> {
+  getBlockTime(block: number): Promise<ResponseDto<number | null>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getBlockTime', [block]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
   getClusterNodes(): Promise<
-    Array<{
-      pubkey: string
-      gossip?: string
-      tpu?: string
-      rpc?: string
-      version?: string
-      featureSet?: number
-      shredVersion?: number
-    }>
+    ResponseDto<
+      Array<{
+        pubkey: string
+        gossip?: string
+        tpu?: string
+        rpc?: string
+        version?: string
+        featureSet?: number
+        shredVersion?: number
+      }>
+    >
   > {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getClusterNodes'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  getEpochInfo(options?: GetCommitmentMinContextSlotOptions): Promise<SolanaEpochInfo> {
+  getEpochInfo(options?: GetCommitmentMinContextSlotOptions): Promise<ResponseDto<SolanaEpochInfo>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getEpochInfo', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  getEpochSchedule(): Promise<SolanaEpochSchedule> {
+  getEpochSchedule(): Promise<ResponseDto<SolanaEpochSchedule>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getEpochSchedule'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  getFeeForMessage(message: any, options?: GetCommitmentMinContextSlotOptions): Promise<number | null> {
+  getFeeForMessage(
+    message: any,
+    options?: GetCommitmentMinContextSlotOptions,
+  ): Promise<ResponseDto<number | null>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getFeeForMessage', [message, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  getFirstAvailableBlock(): Promise<number> {
+  getFirstAvailableBlock(): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getFirstAvailableBlock'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getGenesisHash(): Promise<string> {
+  getGenesisHash(): Promise<ResponseDto<string>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getGenesisHash'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getHealth(): Promise<string> {
+  getHealth(): Promise<ResponseDto<string>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getHealth'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getHighestSnapshotSlot(): Promise<{ full: number; incremental: number }> {
+  getHighestSnapshotSlot(): Promise<ResponseDto<{ full: number; incremental: number }>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getHighestSnapshotSlot'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getIdentity(): Promise<{ identity: string }> {
+  getIdentity(): Promise<ResponseDto<{ identity: string }>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getIdentity'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getInflationGovernor(options?: GetCommitmentOptions): Promise<{
-    initial: number
-    terminal: number
-    taper: number
-    foundation: number
-    foundationTerm: number
-  }> {
+  getInflationGovernor(options?: GetCommitmentOptions): Promise<
+    ResponseDto<{
+      initial: number
+      terminal: number
+      taper: number
+      foundation: number
+      foundationTerm: number
+    }>
+  > {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getInflationGovernor', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getInflationRate(): Promise<{ total: number; validator: number; foundation: number; epoch: number }> {
+  getInflationRate(): Promise<
+    ResponseDto<{ total: number; validator: number; foundation: number; epoch: number }>
+  > {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getInflationRate'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getInflationReward(
     addresses?: string[],
     options?: GetInflationRewardOptions,
   ): Promise<
-    Array<{
-      epoch: number
-      effectiveSlot: number
-      amount: number
-      postBalance: number
-      commission: number
-    }>
+    ResponseDto<
+      Array<{
+        epoch: number
+        effectiveSlot: number
+        amount: number
+        postBalance: number
+        commission: number
+      }>
+    >
   > {
     let params: any = []
     if (addresses) params = [addresses]
@@ -225,185 +242,197 @@ export class SolanaRpc extends AbstractBatchRpc implements SolanaRpcSuite {
 
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getInflationReward', params))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getLargestAccounts(
     options?: GetLargestAccountsOptions,
-  ): Promise<SolanaTypeWithContext<SolanaLargestAccount[]>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaLargestAccount[]>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getLargestAccounts', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getLatestBlockhash(
     options?: GetCommitmentMinContextSlotOptions,
-  ): Promise<SolanaTypeWithContext<SolanaLatestBlockhash>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaLatestBlockhash>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getLatestBlockhash', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getLeaderSchedule(slot?: number, options?: GetLeaderScheduleOptions): Promise<SolanaLeaderSchedule | null> {
+  getLeaderSchedule(
+    slot?: number,
+    options?: GetLeaderScheduleOptions,
+  ): Promise<ResponseDto<SolanaLeaderSchedule | null>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getLeaderSchedule', [slot, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getMaxRetransmitSlot(): Promise<number> {
+  getMaxRetransmitSlot(): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getMaxRetransmitSlot'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getMaxShredInsertSlot(): Promise<number> {
+  getMaxShredInsertSlot(): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getMaxShredInsertSlot'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getMinimumBalanceForRentExemption(dataSize?: number, options?: GetCommitmentOptions): Promise<number> {
+  getMinimumBalanceForRentExemption(
+    dataSize?: number,
+    options?: GetCommitmentOptions,
+  ): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getMinimumBalanceForRentExemption', [dataSize, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getMultipleAccounts(
     pubKeys?: string[],
     options?: GetMultipleAccountsOptions,
-  ): Promise<SolanaTypeWithContext<Array<SolanaAccountInfo | null>>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<Array<SolanaAccountInfo | null>>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getMultipleAccounts', [pubKeys, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getProgramAccounts(
     programId: string,
     options?: GetProgramAccountsOptions,
-  ): Promise<Array<{ account: SolanaAccountInfo; pubkey: string }>> {
+  ): Promise<ResponseDto<Array<{ account: SolanaAccountInfo; pubkey: string }>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getProgramAccounts', [programId, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getRecentPerformanceSamples(limit?: number): Promise<
-    Array<{
-      slot: number
-      numTransactions: number
-      numSlots: number
-      samplePeriodSecs: number
-      numNonVoteTransaction: number
-    }>
+    ResponseDto<
+      Array<{
+        slot: number
+        numTransactions: number
+        numSlots: number
+        samplePeriodSecs: number
+        numNonVoteTransaction: number
+      }>
+    >
   > {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getRecentPerformanceSamples', [limit]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getRecentPrioritizationFees(
     addresses?: string[],
-  ): Promise<Array<{ slot: number; prioritizationFee: number }>> {
+  ): Promise<ResponseDto<Array<{ slot: number; prioritizationFee: number }>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getRecentPrioritizationFees', [addresses]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getSignaturesForAddress(
     address: string,
     options?: GetSignaturesForAddressOptions,
   ): Promise<
-    Array<{
-      signature: string
-      slot: number
-      err: any | null
-      memo: string | null
-      blockTime: number | null
-      confirmationStatus: string | null
-    }>
+    ResponseDto<
+      Array<{
+        signature: string
+        slot: number
+        err: any | null
+        memo: string | null
+        blockTime: number | null
+        confirmationStatus: string | null
+      }>
+    >
   > {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getSignaturesForAddress', [address, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getSignatureStatuses(
     signatures?: string[],
     options?: GetSignatureStatusesOptions,
-  ): Promise<SolanaTypeWithContext<SolanaSignatureStatus>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaSignatureStatus>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getSignatureStatuses', [signatures, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getSlot(options?: GetCommitmentMinContextSlotOptions): Promise<number> {
+  getSlot(options?: GetCommitmentMinContextSlotOptions): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getSlot', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getSlotLeader(options?: GetCommitmentMinContextSlotOptions): Promise<string> {
+  getSlotLeader(options?: GetCommitmentMinContextSlotOptions): Promise<ResponseDto<string>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getSlotLeader', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getSlotLeaders(startSlot?: number, limit?: number): Promise<Array<string>> {
+  getSlotLeaders(startSlot?: number, limit?: number): Promise<ResponseDto<Array<string>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getSlotLeaders', [startSlot, limit]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getStakeActivation(
     pubkey: string,
     options?: GetStakeActivationOptions,
-  ): Promise<{ state: string; active: number; inactive: number }> {
+  ): Promise<ResponseDto<{ state: string; active: number; inactive: number }>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getStakeActivation', [pubkey, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getStakeMinimumDelegation(options?: GetCommitmentOptions): Promise<SolanaTypeWithContext<number>> {
+  getStakeMinimumDelegation(
+    options?: GetCommitmentOptions,
+  ): Promise<ResponseDto<SolanaTypeWithContext<number>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getStakeMinimumDelegation', [options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getSupply(options?: GetSupplyOptions): Promise<SolanaTypeWithContext<SolanaSupply>> {
+  getSupply(options?: GetSupplyOptions): Promise<ResponseDto<SolanaTypeWithContext<SolanaSupply>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getSupply', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getTokenAccountBalance(
     pubkey: string,
     options?: GetCommitmentOptions,
-  ): Promise<SolanaTypeWithContext<SolanaTokenAccountBalance>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenAccountBalance>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getTokenAccountBalance', [pubkey, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getTokenAccountsByDelegate(
     pubkey: string,
     config?: SolanaMint | SolanaProgramId,
     options?: GetTokenAccountsOptions,
-  ): Promise<SolanaTypeWithContext<SolanaTokenAccount[]>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenAccount[]>>> {
     const params: any[] = [pubkey]
     if (config) params.push(config)
     if (options) params.push(options)
@@ -412,108 +441,115 @@ export class SolanaRpc extends AbstractBatchRpc implements SolanaRpcSuite {
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getTokenAccountsByDelegate', params),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getTokenAccountsByOwner(
     pubkey: string,
     config?: SolanaMint | SolanaProgramId,
     options?: GetTokenAccountsOptions,
-  ): Promise<SolanaTypeWithContext<SolanaTokenAccount[]>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenAccount[]>>> {
     const params: any[] = [pubkey]
     if (config) params.push(config)
     if (options) params.push(options)
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getTokenAccountsByOwner', params))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getTokenLargestAccounts(
     pubkey: string,
     options?: GetCommitmentOptions,
-  ): Promise<SolanaTypeWithContext<SolanaAccount[]>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaAccount[]>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getTokenLargestAccounts', [pubkey, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getTokenSupply(
     pubkey: string,
     options?: GetCommitmentOptions,
-  ): Promise<SolanaTypeWithContext<SolanaTokenSupply>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaTokenSupply>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getTokenSupply', [pubkey, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getTransaction(signature: string, options?: GetTransactionOptions): Promise<SolanaTransaction | null> {
+  getTransaction(
+    signature: string,
+    options?: GetTransactionOptions,
+  ): Promise<ResponseDto<SolanaTransaction | null>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('getTransaction', [signature, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getTransactionCount(options?: GetCommitmentMinContextSlotOptions): Promise<number> {
+  getTransactionCount(options?: GetCommitmentMinContextSlotOptions): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getTransactionCount', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  getVersion(): Promise<SolanaVersion> {
+  getVersion(): Promise<ResponseDto<SolanaVersion>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getVersion'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   getVoteAccounts(
     options?: GetVoteAccountOptions,
-  ): Promise<{ current: Array<SolanaVoteAccount>; delinquent: Array<SolanaVoteAccount> }> {
+  ): Promise<ResponseDto<{ current: Array<SolanaVoteAccount>; delinquent: Array<SolanaVoteAccount> }>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('getVoteAccounts', [options]))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   isBlockhashValid(
     blockhash: string,
     options?: GetCommitmentMinContextSlotOptions,
-  ): Promise<SolanaTypeWithContext<boolean>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<boolean>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('isBlockhashValid', [blockhash, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  minimumLedgerSlot(): Promise<number> {
+  minimumLedgerSlot(): Promise<ResponseDto<number>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('minimumLedgerSlot'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  requestAirdrop(pubkey: string, amount: number, options?: GetCommitmentOptions): Promise<string> {
+  requestAirdrop(
+    pubkey: string,
+    amount: number,
+    options?: GetCommitmentOptions,
+  ): Promise<ResponseDto<string>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('requestAirdrop', [pubkey, amount, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
-  sendTransaction(transaction: string, options?: SendTransactionOptions): Promise<string> {
+  sendTransaction(transaction: string, options?: SendTransactionOptions): Promise<ResponseDto<string>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('sendTransaction', [transaction, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
   simulateTransaction(
     transaction: string,
     options?: SimulateTransactionOptions,
-  ): Promise<SolanaTypeWithContext<SolanaTransactionSimulation>> {
+  ): Promise<ResponseDto<SolanaTypeWithContext<SolanaTransactionSimulation>>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('simulateTransaction', [transaction, options]),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 }

--- a/src/service/rpc/TronRpc.ts
+++ b/src/service/rpc/TronRpc.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {Container, Service} from "typedi";
+import { BigNumber } from 'bignumber.js'
+import { Service } from 'typedi'
 import {
   AccountIdentifier,
   AccountPermissionUpdateOptions,
@@ -22,11 +23,10 @@ import {
   UnFreezeAccountOptions,
   UpdateAssetOptions,
   VisibleAndPermissionIdOptions,
-  VisibleOption
-} from "../../dto";
-import {BigNumber} from "bignumber.js";
+  VisibleOption,
+} from '../../dto'
+import { ErrorUtils, ResponseDto, Utils } from '../../util'
 import { AbstractBatchRpc } from './generic'
-import { CONFIG, Utils } from '../../util'
 @Service({
   factory: (data: { id: string }) => {
     return new TronRpc(data.id)
@@ -40,69 +40,119 @@ export class TronRpc extends AbstractBatchRpc implements TronRpcSuite {
     this._id = id
   }
 
-  getRpcNodeUrl(subPath?: string): string {
-    const { apiKey, rpc, network } = Container.of(this._id).get(CONFIG)
-    if (apiKey) {
-      const url =  rpc?.nodes?.[0].url || `https://api.tatum.io/v3/blockchain/node/${network}/${apiKey.v1 ? apiKey.v1 : apiKey.v2}`
-      return url.concat(subPath || "")
-    }
-    return rpc?.nodes?.[0].url  || `https://api.tatum.io/v3/blockchain/node/${network}/`.concat(subPath || "")
+  accountPermissionUpdate(
+    ownerAddress: string,
+    actives: TronPermission[],
+    owner: TronPermission,
+    options?: AccountPermissionUpdateOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/accountpermissionupdate'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, actives, owner, ...options }),
+      }),
+    )
   }
 
-  accountPermissionUpdate(ownerAddress: string, actives: TronPermission[], owner: TronPermission, options?: AccountPermissionUpdateOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/accountpermissionupdate"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, actives, owner, ...options})
-    });
+  broadcastHex(transaction: string): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/broadcasthex'),
+        body: Utils.convertObjCamelToSnake({ transaction }),
+      }),
+    )
   }
 
-  broadcastHex(transaction: string): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/broadcasthex"),
-      body: Utils.convertObjCamelToSnake({transaction})
-    });
+  broadcastTransaction(rawBody: TronTxRawBody): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/broadcasttransaction'),
+        body: Utils.convertObjCamelToSnake(rawBody),
+      }),
+    )
   }
 
-  broadcastTransaction(rawBody: TronTxRawBody): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/broadcasttransaction"),
-      body: Utils.convertObjCamelToSnake(rawBody)
-    });
+  clearAbi(
+    ownerAddress: string,
+    contractAddress: string,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/clearabi'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, contractAddress, ...options }),
+      }),
+    )
   }
 
-  clearAbi(ownerAddress: string, contractAddress: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/clearabi"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, contractAddress, ...options})
-    });
+  createAccount(
+    ownerAddress: string,
+    accountAddress: string,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/createaccount'),
+        body: { ownerAddress, accountAddress, ...options },
+      }),
+    )
   }
 
-  createAccount(ownerAddress: string, accountAddress: string, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/createaccount"),
-      body: {ownerAddress, accountAddress, ...options}
-    });
+  createAssetIssue(
+    ownerAddress: string,
+    name: string,
+    abbr: string,
+    totalSupply: number,
+    trxNum: number,
+    num: number,
+    startTime: number,
+    endTime: number,
+    url: string,
+    options?: CreateAssetIssueOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/createassetissue'),
+        body: { ownerAddress, name, abbr, totalSupply, trxNum, num, startTime, endTime, url, ...options },
+      }),
+    )
   }
 
-  createAssetIssue(ownerAddress: string, name: string, abbr: string, totalSupply: number, trxNum: number, num: number, startTime: number, endTime: number, url: string, options?: CreateAssetIssueOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/createassetissue"),
-      body: {ownerAddress, name, abbr, totalSupply, trxNum, num, startTime, endTime, url, ...options}
-    });
+  createTransaction(
+    ownerAddress: string,
+    toAddress: string,
+    amount: BigNumber,
+    options?: CreateTransactionOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/createtransaction'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, toAddress, amount, ...options }),
+      }),
+    )
   }
 
-  createTransaction(ownerAddress: string, toAddress: string, amount: BigNumber, options?: CreateTransactionOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/createtransaction"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, toAddress, amount, ...options})
-    });
-  }
-
-  delegateResource(ownerAddress: string, receiverAddress: string, balance: BigNumber, resource: TronStakeType, lock: boolean, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/delegateresource"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, receiverAddress, balance, resource, lock, ...options})
-    });
+  delegateResource(
+    ownerAddress: string,
+    receiverAddress: string,
+    balance: BigNumber,
+    resource: TronStakeType,
+    lock: boolean,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/delegateresource'),
+        body: Utils.convertObjCamelToSnake({
+          ownerAddress,
+          receiverAddress,
+          balance,
+          resource,
+          lock,
+          ...options,
+        }),
+      }),
+    )
   }
 
   deployContract(
@@ -110,372 +160,608 @@ export class TronRpc extends AbstractBatchRpc implements TronRpcSuite {
     bytecode: string,
     ownerAddress: string,
     name: string,
-    options?: DeployContractOptions
-  ): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/deploycontract"),
-      body: Utils.convertObjCamelToSnake({
-        abi,
-        bytecode,
-        ownerAddress,
-        name, ...options
-      })
-    });
+    options?: DeployContractOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/deploycontract'),
+        body: Utils.convertObjCamelToSnake({
+          abi,
+          bytecode,
+          ownerAddress,
+          name,
+          ...options,
+        }),
+      }),
+    )
   }
 
-  estimateEnergy(ownerAddress: string, contractAddress: string, functionSelector: string, parameter: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/estimateenergy"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, contractAddress, functionSelector, parameter, ...options})
-    });
+  estimateEnergy(
+    ownerAddress: string,
+    contractAddress: string,
+    functionSelector: string,
+    parameter: string,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/estimateenergy'),
+        body: Utils.convertObjCamelToSnake({
+          ownerAddress,
+          contractAddress,
+          functionSelector,
+          parameter,
+          ...options,
+        }),
+      }),
+    )
   }
 
-  freezeBalance(ownerAddress: string, frozenBalance: BigNumber, frozenDuration: number, resource: TronStakeType, options?: FreezeAccountOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/freezebalance"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, frozenBalance, frozenDuration, resource, ...options})
-    });
+  freezeBalance(
+    ownerAddress: string,
+    frozenBalance: BigNumber,
+    frozenDuration: number,
+    resource: TronStakeType,
+    options?: FreezeAccountOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/freezebalance'),
+        body: Utils.convertObjCamelToSnake({
+          ownerAddress,
+          frozenBalance,
+          frozenDuration,
+          resource,
+          ...options,
+        }),
+      }),
+    )
   }
 
-  freezeBalanceV2(ownerAddress: string, frozenBalance: BigNumber, resource: TronStakeType, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/freezebalancev2"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, frozenBalance, resource, ...options})
-    });
+  freezeBalanceV2(
+    ownerAddress: string,
+    frozenBalance: BigNumber,
+    resource: TronStakeType,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/freezebalancev2'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, frozenBalance, resource, ...options }),
+      }),
+    )
   }
 
-  getAccount(address: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getaccount"),
-      body: Utils.convertObjCamelToSnake({address, ...options})
-    });
+  getAccount(address: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getaccount'),
+        body: Utils.convertObjCamelToSnake({ address, ...options }),
+      }),
+    )
   }
 
-  getAccountBalance(accountIdentifier: AccountIdentifier, blockIdentifier: BlockIdentifier, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getaccountbalance"),
-      body: Utils.convertObjCamelToSnake({accountIdentifier, blockIdentifier, ...options})
-    });
+  getAccountBalance(
+    accountIdentifier: AccountIdentifier,
+    blockIdentifier: BlockIdentifier,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getaccountbalance'),
+        body: Utils.convertObjCamelToSnake({ accountIdentifier, blockIdentifier, ...options }),
+      }),
+    )
   }
 
-  getAccountNet(address: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getaccountnet"),
-      body: Utils.convertObjCamelToSnake({address, ...options})
-    });
+  getAccountNet(address: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getaccountnet'),
+        body: Utils.convertObjCamelToSnake({ address, ...options }),
+      }),
+    )
   }
 
-  getAccountResources(address: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getaccountresource"),
-      body: Utils.convertObjCamelToSnake({address, ...options})
-    });
+  getAccountResources(address: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getaccountresource'),
+        body: Utils.convertObjCamelToSnake({ address, ...options }),
+      }),
+    )
   }
 
-  getAssetIssueByAccount(address: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getassetissuebyaccount"),
-      body: Utils.convertObjCamelToSnake({address, ...options})
-    });
+  getAssetIssueByAccount(address: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getassetissuebyaccount'),
+        body: Utils.convertObjCamelToSnake({ address, ...options }),
+      }),
+    )
   }
 
-  getAssetIssueById(value: number): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getassetissuebyid"),
-      body: Utils.convertObjCamelToSnake({value})
-    });
+  getAssetIssueById(value: number): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getassetissuebyid'),
+        body: Utils.convertObjCamelToSnake({ value }),
+      }),
+    )
   }
 
-  getAssetIssueByName(value: string): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getassetissuebyname"),
-      body: Utils.convertObjCamelToSnake({value})
-    });
+  getAssetIssueByName(value: string): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getassetissuebyname'),
+        body: Utils.convertObjCamelToSnake({ value }),
+      }),
+    )
   }
 
-  getAssetIssueList(): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getassetissuelist"),
-    })
+  getAssetIssueList(): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getassetissuelist'),
+      }),
+    )
   }
 
-  getAssetIssueListByName(value: string): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getassetissuelistbyname"),
-      body: Utils.convertObjCamelToSnake({value})
-    });
+  getAssetIssueListByName(value: string): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getassetissuelistbyname'),
+        body: Utils.convertObjCamelToSnake({ value }),
+      }),
+    )
   }
 
-  getAvailableUnfreezeCount(ownerAddress: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getavailableunfreezecount"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, ...options})
-    });
+  getAvailableUnfreezeCount(ownerAddress: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getavailableunfreezecount'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, ...options }),
+      }),
+    )
   }
 
-  getBandwidthPrices(): Promise<TronPrices> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getbandwidthprices"),
-    });
+  getBandwidthPrices(): Promise<ResponseDto<TronPrices>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getbandwidthprices'),
+      }),
+    )
   }
 
-  getBlock(idOrNum: string, options?: DetailOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getblock"),
-      body: Utils.convertObjCamelToSnake({idOrNum, ...options})
-    });
+  getBlock(idOrNum: string, options?: DetailOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getblock'),
+        body: Utils.convertObjCamelToSnake({ idOrNum, ...options }),
+      }),
+    )
   }
 
-  getBlockBalance(hash: string, number: BigNumber, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getblockbalance"),
-      body: Utils.convertObjCamelToSnake({hash, number, ...options})
-    });
+  getBlockBalance(hash: string, number: BigNumber, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getblockbalance'),
+        body: Utils.convertObjCamelToSnake({ hash, number, ...options }),
+      }),
+    )
   }
 
-  getBlockById(id: string): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getblockbyid"),
-      body: Utils.convertObjCamelToSnake({id})
-    });
+  getBlockById(id: string): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getblockbyid'),
+        body: Utils.convertObjCamelToSnake({ id }),
+      }),
+    )
   }
 
-  getBlockByLatestNum(num: number): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getblockbylatestnum"),
-      body: Utils.convertObjCamelToSnake({num})
-    });
+  getBlockByLatestNum(num: number): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getblockbylatestnum'),
+        body: Utils.convertObjCamelToSnake({ num }),
+      }),
+    )
   }
 
-  getBlockByLimitNext(startNum: number, endNum: number): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getblockbylimitnext"),
-      body: Utils.convertObjCamelToSnake({startNum, endNum})
-    });
+  getBlockByLimitNext(startNum: number, endNum: number): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getblockbylimitnext'),
+        body: Utils.convertObjCamelToSnake({ startNum, endNum }),
+      }),
+    )
   }
 
-  getBlockByNum(num: number): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getblockbynum"),
-      body: Utils.convertObjCamelToSnake({num})
-    });
+  getBlockByNum(num: number): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getblockbynum'),
+        body: Utils.convertObjCamelToSnake({ num }),
+      }),
+    )
   }
 
-  getBurnTRX(): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getburntrx"),
-    });
+  getBurnTRX(): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getburntrx'),
+      }),
+    )
   }
 
-  getCanDelegatedMaxSize(ownerAddress: string, type: TronStakeTypeNumeric, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getcandelegatedmaxsize"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, type, ...options})
-    });
+  getCanDelegatedMaxSize(
+    ownerAddress: string,
+    type: TronStakeTypeNumeric,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getcandelegatedmaxsize'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, type, ...options }),
+      }),
+    )
   }
 
-  getCanWithdrawUnfreezeAmount(ownerAddress: string, options?: GetCanWithdrawUnfreezeAmountOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getcanwithdrawunfreezeamount"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, ...options})
-    });
+  getCanWithdrawUnfreezeAmount(
+    ownerAddress: string,
+    options?: GetCanWithdrawUnfreezeAmountOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getcanwithdrawunfreezeamount'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, ...options }),
+      }),
+    )
   }
 
-  getChainParameters(): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getchainparameters"),
-    });
+  getChainParameters(): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getchainparameters'),
+      }),
+    )
   }
 
-  getContract(value: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getcontract"),
-      body: Utils.convertObjCamelToSnake({value, ...options})
-    });
+  getContract(value: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getcontract'),
+        body: Utils.convertObjCamelToSnake({ value, ...options }),
+      }),
+    )
   }
 
-  getContractInfo(value: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getcontractinfo"),
-      body: Utils.convertObjCamelToSnake({value, ...options})
-    });
+  getContractInfo(value: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getcontractinfo'),
+        body: Utils.convertObjCamelToSnake({ value, ...options }),
+      }),
+    )
   }
 
-  getDelegatedResource(fromAddress: string, toAddress: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getdelegatedresource"),
-      body: Utils.convertObjCamelToSnake({fromAddress, toAddress, ...options})
-    });
+  getDelegatedResource(
+    fromAddress: string,
+    toAddress: string,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getdelegatedresource'),
+        body: Utils.convertObjCamelToSnake({ fromAddress, toAddress, ...options }),
+      }),
+    )
   }
 
-  getDelegatedResourceAccountIndex(value: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getdelegatedresourceaccountindex"),
-      body: Utils.convertObjCamelToSnake({value, ...options})
-    });
+  getDelegatedResourceAccountIndex(value: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getdelegatedresourceaccountindex'),
+        body: Utils.convertObjCamelToSnake({ value, ...options }),
+      }),
+    )
   }
 
-  getDelegatedResourceAccountIndexV2(value: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getdelegatedresourceaccountindexv2"),
-      body: Utils.convertObjCamelToSnake({value, ...options})
-    });
+  getDelegatedResourceAccountIndexV2(value: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getdelegatedresourceaccountindexv2'),
+        body: Utils.convertObjCamelToSnake({ value, ...options }),
+      }),
+    )
   }
 
-  getDelegatedResourceV2(fromAddress: string, toAddress: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getdelegatedresourcev2"),
-      body: Utils.convertObjCamelToSnake({fromAddress, toAddress, ...options})
-    });
+  getDelegatedResourceV2(
+    fromAddress: string,
+    toAddress: string,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getdelegatedresourcev2'),
+        body: Utils.convertObjCamelToSnake({ fromAddress, toAddress, ...options }),
+      }),
+    )
   }
 
-  getEnergyPrices(): Promise<TronPrices> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getenergyprices"),
-    });
+  getEnergyPrices(): Promise<ResponseDto<TronPrices>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getenergyprices'),
+      }),
+    )
   }
 
-  getNodeInfo(): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getnodeinfo"),
-    });
+  getNodeInfo(): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getnodeinfo'),
+      }),
+    )
   }
 
-  getNowBlock(): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getnowblock"),
-    });
+  getNowBlock(): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getnowblock'),
+      }),
+    )
   }
 
-  getPaginatedAssetIssueList(offset: number, limit: number): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/getpaginatedassetissuelist"),
-      body: Utils.convertObjCamelToSnake({offset, limit})
-    });
+  getPaginatedAssetIssueList(offset: number, limit: number): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/getpaginatedassetissuelist'),
+        body: Utils.convertObjCamelToSnake({ offset, limit }),
+      }),
+    )
   }
 
-  getTransactionById(value: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/gettransactionbyid"),
-      body: Utils.convertObjCamelToSnake({value, ...options})
-    });
+  getTransactionById(value: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/gettransactionbyid'),
+        body: Utils.convertObjCamelToSnake({ value, ...options }),
+      }),
+    )
   }
 
-  getTransactionInfoByBlockNum(num: number): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/gettransactioninfobyblocknum"),
-      body: Utils.convertObjCamelToSnake({num})
-    });
+  getTransactionInfoByBlockNum(num: number): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/gettransactioninfobyblocknum'),
+        body: Utils.convertObjCamelToSnake({ num }),
+      }),
+    )
   }
 
-  getTransactionInfoById(value: string): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/gettransactioninfobyid"),
-      body: Utils.convertObjCamelToSnake({value})
-    });
+  getTransactionInfoById(value: string): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/gettransactioninfobyid'),
+        body: Utils.convertObjCamelToSnake({ value }),
+      }),
+    )
   }
 
-  listNodes(): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/listnodes"),
-    });
+  listNodes(): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/listnodes'),
+      }),
+    )
   }
 
-  participateAssetIssue(toAddress: string, ownerAddress: string, assetName: string, amount: BigNumber, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/participateassetissue"),
-      body: Utils.convertObjCamelToSnake({toAddress, ownerAddress, assetName, amount, ...options})
-    });
+  participateAssetIssue(
+    toAddress: string,
+    ownerAddress: string,
+    assetName: string,
+    amount: BigNumber,
+    options?: VisibleOption,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/participateassetissue'),
+        body: Utils.convertObjCamelToSnake({ toAddress, ownerAddress, assetName, amount, ...options }),
+      }),
+    )
   }
 
-  transferAsset(ownerAddress: string, toAddress: string, assetName: string, amount: BigNumber, options?: TransferAssetIssueByAccountOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/transferasset"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, toAddress, assetName, amount, ...options})
-    });
+  transferAsset(
+    ownerAddress: string,
+    toAddress: string,
+    assetName: string,
+    amount: BigNumber,
+    options?: TransferAssetIssueByAccountOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/transferasset'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, toAddress, assetName, amount, ...options }),
+      }),
+    )
   }
 
-  triggerConstantContract(ownerAddress: string, contractAddress: string, functionSelector: string, parameter: string, options?: TriggerConstantContractOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/triggerconstantcontract"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, contractAddress, functionSelector, parameter, ...options})
-    });
+  triggerConstantContract(
+    ownerAddress: string,
+    contractAddress: string,
+    functionSelector: string,
+    parameter: string,
+    options?: TriggerConstantContractOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/triggerconstantcontract'),
+        body: Utils.convertObjCamelToSnake({
+          ownerAddress,
+          contractAddress,
+          functionSelector,
+          parameter,
+          ...options,
+        }),
+      }),
+    )
   }
 
-  triggerSmartContract(ownerAddress: string, contractAddress: string, functionSelector: string, parameter: string, options?: TriggerSmartContractOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/triggersmartcontract"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, contractAddress, functionSelector, parameter, ...options})
-    });
+  triggerSmartContract(
+    ownerAddress: string,
+    contractAddress: string,
+    functionSelector: string,
+    parameter: string,
+    options?: TriggerSmartContractOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/triggersmartcontract'),
+        body: Utils.convertObjCamelToSnake({
+          ownerAddress,
+          contractAddress,
+          functionSelector,
+          parameter,
+          ...options,
+        }),
+      }),
+    )
   }
 
-  unDelegateResource(ownerAddress: string, receiverAddress: string, balance: BigNumber, resource: TronStakeType, lock: boolean, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/undelegateresource"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, receiverAddress, balance, resource, lock, ...options})
-    });
+  unDelegateResource(
+    ownerAddress: string,
+    receiverAddress: string,
+    balance: BigNumber,
+    resource: TronStakeType,
+    lock: boolean,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/undelegateresource'),
+        body: Utils.convertObjCamelToSnake({
+          ownerAddress,
+          receiverAddress,
+          balance,
+          resource,
+          lock,
+          ...options,
+        }),
+      }),
+    )
   }
 
-  unfreezeAsset(ownerAddress: string, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/unfreezeasset"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, ...options})
-    });
+  unfreezeAsset(ownerAddress: string, options?: VisibleAndPermissionIdOptions): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/unfreezeasset'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, ...options }),
+      }),
+    )
   }
 
-  unfreezeBalance(ownerAddress: string, resource: TronStakeType, options?: UnFreezeAccountOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/unfreezebalance"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, resource, ...options})
-    });
+  unfreezeBalance(
+    ownerAddress: string,
+    resource: TronStakeType,
+    options?: UnFreezeAccountOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/unfreezebalance'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, resource, ...options }),
+      }),
+    )
   }
 
-  unfreezeBalanceV2(ownerAddress: string, unfreezeBalance: BigNumber, resource: TronStakeType, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/unfreezebalancev2"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, unfreezeBalance, resource, ...options})
-    });
+  unfreezeBalanceV2(
+    ownerAddress: string,
+    unfreezeBalance: BigNumber,
+    resource: TronStakeType,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/unfreezebalancev2'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, unfreezeBalance, resource, ...options }),
+      }),
+    )
   }
 
-  updateAccount(ownerAddress: string, accountName: string, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/updateaccount"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, accountName, ...options})
-    });
+  updateAccount(
+    ownerAddress: string,
+    accountName: string,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/updateaccount'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, accountName, ...options }),
+      }),
+    )
   }
 
-  updateAsset(ownerAddress: string, url: string, options?: UpdateAssetOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/updateasset"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, url, ...options})
-    });
+  updateAsset(ownerAddress: string, url: string, options?: UpdateAssetOptions): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/updateasset'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, url, ...options }),
+      }),
+    )
   }
 
-  updateEnergyLimit(ownerAddress: string, contractAddress: string, originEnergyLimit: number, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/updateenergylimit"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, contractAddress, originEnergyLimit, ...options})
-    });
+  updateEnergyLimit(
+    ownerAddress: string,
+    contractAddress: string,
+    originEnergyLimit: number,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/updateenergylimit'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, contractAddress, originEnergyLimit, ...options }),
+      }),
+    )
   }
 
-  updateSetting(ownerAddress: string, contractAddress: string, consumeUserResourcePercent: number, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/updatesetting"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, contractAddress, consumeUserResourcePercent, ...options})
-    });
+  updateSetting(
+    ownerAddress: string,
+    contractAddress: string,
+    consumeUserResourcePercent: number,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/updatesetting'),
+        body: Utils.convertObjCamelToSnake({
+          ownerAddress,
+          contractAddress,
+          consumeUserResourcePercent,
+          ...options,
+        }),
+      }),
+    )
   }
 
-  validateAddress(address: string, options?: VisibleOption): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/validateaddress"),
-      body: Utils.convertObjCamelToSnake({address, ...options})
-    });
+  validateAddress(address: string, options?: VisibleOption): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/validateaddress'),
+        body: Utils.convertObjCamelToSnake({ address, ...options }),
+      }),
+    )
   }
 
-  withdrawExpireUnfreeze(ownerAddress: string, options?: VisibleAndPermissionIdOptions): Promise<any> {
-    return this.connector.post({
-      path: this.getRpcNodeUrl("/wallet/withdrawexpireunfreeze"),
-      body: Utils.convertObjCamelToSnake({ownerAddress, ...options})
-    });
+  withdrawExpireUnfreeze(
+    ownerAddress: string,
+    options?: VisibleAndPermissionIdOptions,
+  ): Promise<ResponseDto<any>> {
+    return ErrorUtils.tryFail(() =>
+      this.connector.post({
+        path: this.getRpcNodeUrl('/wallet/withdrawexpireunfreeze'),
+        body: Utils.convertObjCamelToSnake({ ownerAddress, ...options }),
+      }),
+    )
   }
 }

--- a/src/service/rpc/XrpRpc.ts
+++ b/src/service/rpc/XrpRpc.ts
@@ -26,11 +26,10 @@ import {
   TxJson,
   TxOptions,
   TypeOption,
-  XrpResult,
   XrpRpcSuite,
 } from '../../dto'
+import { ResponseDto, ResponseUtils, Utils } from '../../util'
 import { AbstractBatchRpc } from './generic'
-import { Utils } from '../../util'
 
 const generateXrpParams = (required?: { [key: string]: any }, optional?: { [key: string]: any }) => {
   const xrpParams: { [name: string]: unknown } = {}
@@ -52,7 +51,7 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
     super(id)
   }
 
-  accountChannels(account: string, options?: AccountChannelsOptions): Promise<XrpResult> {
+  accountChannels(account: string, options?: AccountChannelsOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -66,46 +65,46 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           ),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  accountCurrencies(account: string, options?: Ledger & StrictOption): Promise<XrpResult> {
+  accountCurrencies(account: string, options?: Ledger & StrictOption): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('account_currencies', generateXrpParams({ account }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  accountInfo(account: string, options?: AccountInfoOptions): Promise<XrpResult> {
+  accountInfo(account: string, options?: AccountInfoOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('account_info', generateXrpParams({ account }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  accountLines(account: string, options?: AccountLinesOptions): Promise<XrpResult> {
+  accountLines(account: string, options?: AccountLinesOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('account_lines', generateXrpParams({ account }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  accountNfts(account: string, options?: Ledger & Pagination): Promise<XrpResult> {
+  accountNfts(account: string, options?: Ledger & Pagination): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('account_nfts', generateXrpParams({ account }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  accountObjects(account: string, options?: AccountObjectsOptions): Promise<XrpResult> {
+  accountObjects(account: string, options?: AccountObjectsOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -119,19 +118,19 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           ),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  accountOffers(account: string, options?: Ledger & Pagination & StrictOption): Promise<XrpResult> {
+  accountOffers(account: string, options?: Ledger & Pagination & StrictOption): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('account_offers', generateXrpParams({ account }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  accountTx(account: string, options?: AccountTxOptions): Promise<XrpResult> {
+  accountTx(account: string, options?: AccountTxOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -145,67 +144,67 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           ),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  gatewayBalances(account: string, options?: GatewayBalancesOptions): Promise<XrpResult> {
+  gatewayBalances(account: string, options?: GatewayBalancesOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('gateway_balances', generateXrpParams({ account }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  norippleCheck(account: string, role: string, options?: NorippleCheckOptions): Promise<XrpResult> {
+  norippleCheck(account: string, role: string, options?: NorippleCheckOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('noripple_check', generateXrpParams({ account, role }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  ledger(options?: LedgerOptions): Promise<XrpResult> {
+  ledger(options?: LedgerOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('ledger', generateXrpParams({}, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  ledgerClosed(): Promise<XrpResult> {
+  ledgerClosed(): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('ledger_closed'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  ledgerCurrent(): Promise<XrpResult> {
+  ledgerCurrent(): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('ledger_current'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  ledgerData(options?: Ledger & LedgerBinaryOption & Pagination & TypeOption): Promise<XrpResult> {
+  ledgerData(options?: Ledger & LedgerBinaryOption & Pagination & TypeOption): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('ledger_data', generateXrpParams({}, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  ledgerEntry(options?: LedgerEntryOptions): Promise<XrpResult> {
+  ledgerEntry(options?: LedgerEntryOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('ledger_entry', generateXrpParams({}, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  submit(tx: Transaction, options?: Secrets & FailOption & AutoFilling): Promise<XrpResult> {
+  submit(tx: Transaction, options?: Secrets & FailOption & AutoFilling): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -214,46 +213,46 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           generateXrpParams(typeof tx === 'string' ? { txBlob: tx } : { txJson: tx }, options),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  submitMultisigned(txJson: TxJson, options?: FailOption): Promise<XrpResult> {
+  submitMultisigned(txJson: TxJson, options?: FailOption): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('submit_multisigned', generateXrpParams({ txJson }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  transactionEntry(txHash: string, options?: Ledger): Promise<XrpResult> {
+  transactionEntry(txHash: string, options?: Ledger): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('transaction_entry', generateXrpParams({ txHash }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  tx(transaction: string, options?: TxOptions): Promise<XrpResult> {
+  tx(transaction: string, options?: TxOptions): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('tx', generateXrpParams({ transaction }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  txHistory(start: number): Promise<XrpResult> {
+  txHistory(start: number): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('txHistory', generateXrpParams({ start })),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  sign(txJson: TxJson, options?: Secrets & AutoFilling): Promise<XrpResult> {
+  sign(txJson: TxJson, options?: Secrets & AutoFilling): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -267,28 +266,36 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           ),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  signFor(account: string, txJson: TxJson, options?: Secrets): Promise<XrpResult> {
+  signFor(account: string, txJson: TxJson, options?: Secrets): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('sign_for', generateXrpParams({ account, txJson }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  bookOffers(takerGets: Currency, takerPays: Currency, options?: BookOffersOptions): Promise<XrpResult> {
+  bookOffers(
+    takerGets: Currency,
+    takerPays: Currency,
+    options?: BookOffersOptions,
+  ): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('book_offers', generateXrpParams({ takerGets, takerPays }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  depositAuthorized(sourceAccount: string, destinationAccount: string, options?: Ledger): Promise<XrpResult> {
+  depositAuthorized(
+    sourceAccount: string,
+    destinationAccount: string,
+    options?: Ledger,
+  ): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -303,25 +310,25 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           ),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  nftBuyOffers(nftId: string, options?: Ledger & Pagination): Promise<XrpResult> {
+  nftBuyOffers(nftId: string, options?: Ledger & Pagination): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('nft_buy_offers', generateXrpParams({ nftId }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  nftSellOffers(nftId: string, options?: Ledger & Pagination): Promise<XrpResult> {
+  nftSellOffers(nftId: string, options?: Ledger & Pagination): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('nft_sell_offers', generateXrpParams({ nftId }, options)),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
   ripplePathFind(
@@ -329,7 +336,7 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
     destinationAccount: string,
     destinationAmount: CurrencyAmount,
     options?: RipplePathFindOptions,
-  ): Promise<XrpResult> {
+  ): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -345,10 +352,10 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           ),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  channelAuthorize(amount: string, channelId: string, options?: Secrets): Promise<XrpResult> {
+  channelAuthorize(amount: string, channelId: string, options?: Secrets): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
@@ -363,54 +370,65 @@ export class XrpRpc extends AbstractBatchRpc implements XrpRpcSuite {
           ),
         ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  channelVerify(amount: string, channelId: string, publicKey: string, signature: string): Promise<XrpResult> {
+  channelVerify(
+    amount: string,
+    channelId: string,
+    publicKey: string,
+    signature: string,
+  ): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
-        Utils.prepareRpcCall('channel_verify', generateXrpParams({ amount, channelId, publicKey, signature })),
+        Utils.prepareRpcCall(
+          'channel_verify',
+          generateXrpParams({ amount, channelId, publicKey, signature }),
+        ),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  fee(): Promise<XrpResult> {
+  fee(): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('fee'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  serverInfo(): Promise<XrpResult> {
+  serverInfo(): Promise<ResponseDto<any>> {
     return this.connector
-      .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('server_info', generateXrpParams()))
-      .then((r) => r.result)
+      .rpcCall<JsonRpcResponse>(
+        this.getRpcNodeUrl(),
+        Utils.prepareRpcCall('server_info', generateXrpParams()),
+      )
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  serverState(): Promise<XrpResult> {
+  serverState(): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('server_state'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  manifest(publicKey: string): Promise<XrpResult> {
+  manifest(publicKey: string): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(
         this.getRpcNodeUrl(),
         Utils.prepareRpcCall('manifest', generateXrpParams({ publicKey })),
       )
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  ping(): Promise<XrpResult> {
+  ping(): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('ping'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 
-  random(): Promise<XrpResult> {
+  random(): Promise<ResponseDto<any>> {
     return this.connector
       .rpcCall<JsonRpcResponse>(this.getRpcNodeUrl(), Utils.prepareRpcCall('random'))
-      .then((r) => r.result)
+      .then((r) => ResponseUtils.fromRpcResult(r))
   }
 }

--- a/src/service/rpc/evm/AbstractEvmBasedRpc.ts
+++ b/src/service/rpc/evm/AbstractEvmBasedRpc.ts
@@ -10,37 +10,46 @@ import {
   TraceType,
   TxPayload,
 } from '../../../dto'
+import { ErrorUtils, ResponseDto, ResponseUtils, Status } from '../../../util'
 
 @Service()
 export abstract class AbstractEvmBasedRpc implements EvmBasedRpcInterface {
   protected abstract rpcCall<T>(method: string, params?: unknown[]): Promise<T>
 
-  async blockNumber(): Promise<BigNumber> {
+  async blockNumber(): Promise<ResponseDto<BigNumber>> {
     const r = await this.rpcCall<JsonRpcResponse>('eth_blockNumber')
-    return new BigNumber(r.result)
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
+    }
+    return response
   }
 
-  async call(callObject: TxPayload, blockNumber?: BlockNumber): Promise<string> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_call', [callObject,
-        typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
-      ])
-    return r.result;
+  async call(callObject: TxPayload, blockNumber?: BlockNumber): Promise<ResponseDto<string>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_call', [
+      callObject,
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async chainId(): Promise<BigNumber> {
-    const r = await this.rpcCall<JsonRpcResponse>('eth_chainId');
-    return new BigNumber(r.result);
+  async chainId(): Promise<ResponseDto<BigNumber>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_chainId')
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
+    }
+    return response
   }
 
-  async clientVersion(): Promise<string> {
+  async clientVersion(): Promise<ResponseDto<string>> {
     const r = await this.rpcCall<JsonRpcResponse>('web3_clientVersion')
-    return r.result;
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async debugGetBadBlocks(): Promise<any> {
+  async debugGetBadBlocks(): Promise<ResponseDto<any>> {
     const r = await this.rpcCall<JsonRpcResponse>('debug_getBadBlocks')
-    return r.result;
+    return ResponseUtils.fromRpcResult(r)
   }
 
   async debugStorageRangeAt(
@@ -49,320 +58,376 @@ export abstract class AbstractEvmBasedRpc implements EvmBasedRpcInterface {
     contractAddress: string,
     startKey: string,
     maxResult: string,
-  ): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'debug_storageRangeAt', [blockHash,
-        txIndex,
-        contractAddress,
-        startKey,
-        maxResult,
-      ])
-    return r.result;
+  ): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('debug_storageRangeAt', [
+      blockHash,
+      txIndex,
+      contractAddress,
+      startKey,
+      maxResult,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async debugTraceBlockByHash(blockHash: string, traceOptions?: TraceOptions): Promise<any> {
-    const params: unknown[] = [blockHash];
+  async debugTraceBlockByHash(blockHash: string, traceOptions?: TraceOptions): Promise<ResponseDto<any>> {
+    const params: unknown[] = [blockHash]
     if (traceOptions) {
-      params.push(traceOptions);
+      params.push(traceOptions)
     }
     const r = await this.rpcCall<JsonRpcResponse>('debug_traceBlockByHash', params)
-    return r.result;
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async debugTraceBlockByNumber(blockHash: string | number, traceOptions?: TraceOptions): Promise<any> {
-    const params: unknown[] = [`0x${new BigNumber(blockHash).toString(16)}`];
+  async debugTraceBlockByNumber(
+    blockHash: string | number,
+    traceOptions?: TraceOptions,
+  ): Promise<ResponseDto<any>> {
+    const params: unknown[] = [`0x${new BigNumber(blockHash).toString(16)}`]
     if (traceOptions) {
-      params.push(traceOptions);
+      params.push(traceOptions)
     }
     const r = await this.rpcCall<JsonRpcResponse>('debug_traceBlockByNumber', params)
-    return r.result;
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async debugTraceCall(callObject: TxPayload, blockNumber: BlockNumber, traceOptions?: TraceOptions): Promise<any> {
-    const params: unknown[] = [callObject, blockNumber];
+  async debugTraceCall(
+    callObject: TxPayload,
+    blockNumber: BlockNumber,
+    traceOptions?: TraceOptions,
+  ): Promise<ResponseDto<any>> {
+    const params: unknown[] = [callObject, blockNumber]
     if (traceOptions) {
-      params.push(traceOptions);
+      params.push(traceOptions)
     }
-    const r = await this.rpcCall <JsonRpcResponse>('debug_traceCall', params,
-    )
-    return r.result;
+    const r = await this.rpcCall<JsonRpcResponse>('debug_traceCall', params)
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async debugTraceTransaction(txHash: string, traceOptions?: TraceOptions): Promise<any> {
-    const params: unknown[] = [txHash];
+  async debugTraceTransaction(txHash: string, traceOptions?: TraceOptions): Promise<ResponseDto<any>> {
+    const params: unknown[] = [txHash]
     if (traceOptions) {
-      params.push(traceOptions);
+      params.push(traceOptions)
     }
     const r = await this.rpcCall<JsonRpcResponse>('debug_traceTransaction', params)
-    return r.result;
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async estimateGas(callObject: TxPayload): Promise<BigNumber> {
+  async estimateGas(callObject: TxPayload): Promise<ResponseDto<BigNumber>> {
     const r = await this.rpcCall<JsonRpcResponse>('eth_estimateGas', [callObject])
-    return new BigNumber(r.result)
+
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
+    }
+    return response
   }
 
-  async gasPrice(): Promise<BigNumber> {
+  async gasPrice(): Promise<ResponseDto<BigNumber>> {
     const r = await this.rpcCall<JsonRpcResponse>('eth_gasPrice')
-    return new BigNumber(r.result);
-  }
-
-  async maxPriorityFeePerGas(): Promise<BigNumber> {
-    const r = await this.rpcCall <JsonRpcResponse>('eth_maxPriorityFeePerGas')
-    return new BigNumber(r.result);
-  }
-
-  async getBalance(address: string, blockNumber?: BlockNumber): Promise<BigNumber> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getBalance',
-      [address, typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber],
-    )
-    return new BigNumber(r.result)
-  }
-
-  async getTokenDecimals(tokenAddress: string): Promise<BigNumber> {
-    const r = await this.rpcCall<JsonRpcResponse>('eth_call', [{ to: tokenAddress, data: '0x313ce567' }, 'latest'])
-    return new BigNumber(r.result);
-  }
-
-  async getContractAddress(txHash: string): Promise<string | null> {
-    try {
-      const txReceipt = await this.getTransactionReceipt(txHash)
-      return txReceipt.contractAddress
-    } catch (e) {
-      console.error('Failed to get contract address, transaction does not exist, or is not a contract creation tx or is not mined yet.')
-      return null
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
     }
+    return response
   }
 
-  async getBlockByHash(blockHash: string, includeTransactions = false): Promise<any> {
-    const r = await this.rpcCall <JsonRpcResponse>('eth_getBlockByHash', [blockHash, includeTransactions])
-    return r.result;
+  async maxPriorityFeePerGas(): Promise<ResponseDto<BigNumber>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_maxPriorityFeePerGas')
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
+    }
+    return response
   }
 
-  async getBlockTransactionCountByHash(blockHash: string): Promise<number> {
-    const r = await this.rpcCall <JsonRpcResponse>('eth_getBlockTransactionCountByHash', [blockHash])
-    return r.result;
+  async getBalance(address: string, blockNumber?: BlockNumber): Promise<ResponseDto<BigNumber>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getBalance', [
+      address,
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
+    }
+    return response
   }
 
-  async getBlockByNumber(blockNumber: BlockNumber, full?: boolean): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getBlockByNumber',
-      [typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber, full],
-    )
-    return r.result
+  async getTokenDecimals(tokenAddress: string): Promise<ResponseDto<BigNumber>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_call', [
+      { to: tokenAddress, data: '0x313ce567' },
+      'latest',
+    ])
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
+    }
+    return response
   }
 
-  async getBlockTransactionCountByNumber(blockNumber: BlockNumber): Promise<number> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getBlockTransactionCountByNumber',
-      [typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber],
-    )
-    return r.result
+  async getContractAddress(txHash: string): Promise<ResponseDto<string | null>> {
+    const txReceipt = await this.getTransactionReceipt(txHash)
+    if (txReceipt.data?.contractAddress) {
+      return {
+        data: txReceipt.data.contractAddress,
+        status: Status.SUCCESS,
+      } as ResponseDto<string>
+    }
+
+    return {
+      status: Status.ERROR,
+      error: ErrorUtils.toErrorWithMessage(
+        'Failed to get contract address, transaction does not exist, or is not a contract creation tx or is not mined yet.',
+      ),
+    } as ResponseDto<string>
   }
 
-  async getCode(address: string, blockNumber?: BlockNumber): Promise<string> {
-    if(!blockNumber){
+  async getBlockByHash(blockHash: string, includeTransactions = false): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getBlockByHash', [blockHash, includeTransactions])
+    return ResponseUtils.fromRpcResult(r)
+  }
+
+  async getBlockTransactionCountByHash(blockHash: string): Promise<ResponseDto<number>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getBlockTransactionCountByHash', [blockHash])
+    return ResponseUtils.fromRpcResult(r)
+  }
+
+  async getBlockByNumber(blockNumber: BlockNumber, full?: boolean): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getBlockByNumber', [
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+      full,
+    ])
+    return ResponseUtils.fromRpcResult(r)
+  }
+
+  async getBlockTransactionCountByNumber(blockNumber: BlockNumber): Promise<ResponseDto<number>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getBlockTransactionCountByNumber', [
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    return ResponseUtils.fromRpcResult(r)
+  }
+
+  async getCode(address: string, blockNumber?: BlockNumber): Promise<ResponseDto<string>> {
+    if (!blockNumber) {
       blockNumber = 'latest'
     }
 
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getCode',
-      [address, typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber],
-    )
-    return r.result
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getCode', [
+      address,
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getLogs(filter: LogFilter): Promise<any> {
+  async getLogs(filter: LogFilter): Promise<ResponseDto<any>> {
     const r = await this.rpcCall<JsonRpcResponse>('eth_getLogs', [filter])
-    return r.result
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getProof(address: string, storageKeys: string[], blockNumber?: BlockNumber): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getProof', [address,
-        storageKeys,
-        typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
-      ])
-    return r.result;
+  async getProof(
+    address: string,
+    storageKeys: string[],
+    blockNumber?: BlockNumber,
+  ): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getProof', [
+      address,
+      storageKeys,
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getStorageAt(address: string, position: string, blockNumber?: BlockNumber): Promise<string> {
-    if(!blockNumber){
+  async getStorageAt(
+    address: string,
+    position: string,
+    blockNumber?: BlockNumber,
+  ): Promise<ResponseDto<string>> {
+    if (!blockNumber) {
       blockNumber = 'latest'
     }
 
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getStorageAt', [address,
-        position,
-        typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
-      ])
-    return r.result;
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getStorageAt', [
+      address,
+      position,
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getTransactionByBlockHashAndIndex(blockHash: string, index: number): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getTransactionByBlockHashAndIndex', [blockHash,
-        `0x${new BigNumber(index).toString(16)}`,
-      ])
-    return r.result;
+  async getTransactionByBlockHashAndIndex(blockHash: string, index: number): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getTransactionByBlockHashAndIndex', [
+      blockHash,
+      `0x${new BigNumber(index).toString(16)}`,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getTransactionByBlockNumberAndIndex(blockNumber: string | number, index: number): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getTransactionByBlockNumberAndIndex', [`0x${new BigNumber(blockNumber).toString(16)}`,
-        `0x${new BigNumber(index).toString(16)}`,
-      ])
-    return r.result;
+  async getTransactionByBlockNumberAndIndex(
+    blockNumber: string | number,
+    index: number,
+  ): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getTransactionByBlockNumberAndIndex', [
+      `0x${new BigNumber(blockNumber).toString(16)}`,
+      `0x${new BigNumber(index).toString(16)}`,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getTransactionByHash(txHash: string): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getTransactionByHash', [txHash]);
-    return r.result;
+  async getTransactionByHash(txHash: string): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getTransactionByHash', [txHash])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-
-  async getTransactionCount(address: string, blockNumber?: BlockNumber): Promise<BigNumber> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getTransactionCount',
-      [address, typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber],
-    )
-    return new BigNumber(r.result)
+  async getTransactionCount(address: string, blockNumber?: BlockNumber): Promise<ResponseDto<BigNumber>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getTransactionCount', [
+      address,
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    const response = ResponseUtils.fromRpcResult<BigNumber>(r)
+    if (response.data) {
+      response.data = new BigNumber(r.result)
+    }
+    return response
   }
 
-
-  async getTransactionReceipt(transactionHash: string): Promise<any> {
+  async getTransactionReceipt(transactionHash: string): Promise<ResponseDto<any>> {
     const r = await this.rpcCall<JsonRpcResponse>('eth_getTransactionReceipt', [transactionHash])
-    return r.result
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getUncleByBlockHashAndIndex(blockHash: string, index: number): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getUncleByBlockHashAndIndex', [blockHash,
-        `0x${new BigNumber(index).toString(16)}`,
-      ])
-    return r.result;
+  async getUncleByBlockHashAndIndex(blockHash: string, index: number): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getUncleByBlockHashAndIndex', [
+      blockHash,
+      `0x${new BigNumber(index).toString(16)}`,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getUncleByBlockNumberAndIndex(blockNumber: string | number, index: number): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getUncleByBlockNumberAndIndex', [`0x${new BigNumber(blockNumber).toString(16)}`,
-        `0x${new BigNumber(index).toString(16)}`,
-      ])
-    return r.result;
+  async getUncleByBlockNumberAndIndex(
+    blockNumber: string | number,
+    index: number,
+  ): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getUncleByBlockNumberAndIndex', [
+      `0x${new BigNumber(blockNumber).toString(16)}`,
+      `0x${new BigNumber(index).toString(16)}`,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getUncleCountByBlockHash(blockHash: string): Promise<string> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getUncleCountByBlockHash', [blockHash]);
-    return r.result;
+  async getUncleCountByBlockHash(blockHash: string): Promise<ResponseDto<string>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getUncleCountByBlockHash', [blockHash])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async getUncleCountByBlockNumber(blockNumber: string | number): Promise<string> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_getUncleCountByBlockNumber', [`0x${new BigNumber(blockNumber).toString(16)}`,
-      ]);
-    return r.result;
+  async getUncleCountByBlockNumber(blockNumber: string | number): Promise<ResponseDto<string>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_getUncleCountByBlockNumber', [
+      `0x${new BigNumber(blockNumber).toString(16)}`,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async protocolVersion(): Promise<string> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_protocolVersion');
-    return r.result;
+  async protocolVersion(): Promise<ResponseDto<string>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_protocolVersion')
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async sendRawTransaction(signedTransactionData: string): Promise<string> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_sendRawTransaction', [signedTransactionData]);
-    return r.result;
+  async sendRawTransaction(signedTransactionData: string): Promise<ResponseDto<string>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_sendRawTransaction', [signedTransactionData])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async sha3(data: string): Promise<string> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'web3_sha', [data])
-    ;
-    return r.result;
+  async sha3(data: string): Promise<ResponseDto<string>> {
+    const r = await this.rpcCall<JsonRpcResponse>('web3_sha', [data])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async syncing(): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'eth_syncing')
-    ;
-    return r.result;
+  async syncing(): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('eth_syncing')
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async traceBlock(blockNumber: BlockNumber, traceOptions?: TraceOptions): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'trace_block',
-      [typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber, traceOptions],
-    )
-    return r.result
+  async traceBlock(blockNumber: BlockNumber, traceOptions?: TraceOptions): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('trace_block', [
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+      traceOptions,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async traceCall(callObject: TxPayload, traceTypes: TraceType[], blockNumber?: BlockNumber): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'trace_call',
-      [
-        callObject,
-        traceTypes,
-        { blockNumber: typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber },
-      ],
-    )
-    return r.result
+  async traceCall(
+    callObject: TxPayload,
+    traceTypes: TraceType[],
+    blockNumber?: BlockNumber,
+  ): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('trace_call', [
+      callObject,
+      traceTypes,
+      {
+        blockNumber:
+          typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+      },
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async traceCallMany(callObject: TxPayload[], traceType: TraceType[][], blockNumber: BlockNumber): Promise<any> {
+  async traceCallMany(
+    callObject: TxPayload[],
+    traceType: TraceType[][],
+    blockNumber: BlockNumber,
+  ): Promise<ResponseDto<any>> {
     const params = callObject.map((call, index) => {
       return [call, traceType[index]]
-    });
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'trace_callMany', [params,
-        typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
-      ])
-    return r.result;
+    })
+    const r = await this.rpcCall<JsonRpcResponse>('trace_callMany', [
+      params,
+      typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async traceRawTransaction(signedTransactionData: string, traceOptions: TraceType[]): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'trace_rawTransaction', [signedTransactionData, traceOptions])
-    return r.result;
+  async traceRawTransaction(
+    signedTransactionData: string,
+    traceOptions: TraceType[],
+  ): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('trace_rawTransaction', [
+      signedTransactionData,
+      traceOptions,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async traceReplayBlockTransactions(blockNumber: BlockNumber, traceOptions: TraceType[]): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'trace_replayBlockTransactions', [blockNumber, traceOptions])
-    return r.result;
+  async traceReplayBlockTransactions(
+    blockNumber: BlockNumber,
+    traceOptions: TraceType[],
+  ): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('trace_replayBlockTransactions', [
+      blockNumber,
+      traceOptions,
+    ])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async traceReplayTransaction(txHash: string, traceOptions: TraceType[]): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'trace_replayTransaction', [txHash, traceOptions])
-    return r.result;
+  async traceReplayTransaction(txHash: string, traceOptions: TraceType[]): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('trace_replayTransaction', [txHash, traceOptions])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async traceTransaction(txHash: string): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'trace_transaction', [txHash])
-    return r.result;
+  async traceTransaction(txHash: string): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('trace_transaction', [txHash])
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async txPoolContent(): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'txpool_content')
-    return r.result;
+  async txPoolContent(): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('txpool_content')
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async txPoolInspect(): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'txpool_inspect')
-    return r.result;
+  async txPoolInspect(): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('txpool_inspect')
+    return ResponseUtils.fromRpcResult(r)
   }
 
-  async txPoolStatus(): Promise<any> {
-    const r = await this.rpcCall<JsonRpcResponse>(
-      'txpool_status')
-    return r.result;
+  async txPoolStatus(): Promise<ResponseDto<any>> {
+    const r = await this.rpcCall<JsonRpcResponse>('txpool_status')
+    return ResponseUtils.fromRpcResult(r)
   }
 }
-

--- a/src/service/rpc/utxo/AbstractUtxoBasedRpc.ts
+++ b/src/service/rpc/utxo/AbstractUtxoBasedRpc.ts
@@ -1,136 +1,146 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { JsonRpcResponse, UtxoBasedRpcInterface } from '../../../dto'
+import { ResponseDto, ResponseUtils } from '../../../util'
 
 export abstract class AbstractUtxoBasedRpc implements UtxoBasedRpcInterface {
   protected abstract rpcCall<T>(method: string, params?: unknown[]): Promise<T>
 
-  async createRawTransaction(inputs: any[], outputs: any, locktime = 0, replaceable = false): Promise<string> {
-    const res = await this.rpcCall<JsonRpcResponse>('createrawtransaction', [inputs, outputs, locktime, replaceable]);
-    return res.result;
+  async createRawTransaction(
+    inputs: any[],
+    outputs: any,
+    locktime = 0,
+    replaceable = false,
+  ): Promise<ResponseDto<string>> {
+    const res = await this.rpcCall<JsonRpcResponse>('createrawtransaction', [
+      inputs,
+      outputs,
+      locktime,
+      replaceable,
+    ])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async decodeRawTransaction(hexstring: string): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('decoderawtransaction', [hexstring]);
-    return res.result;
+  async decodeRawTransaction(hexstring: string): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('decoderawtransaction', [hexstring])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async decodeScript(hexstring: string): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('decodescript', [hexstring]);
-    return res.result;
+  async decodeScript(hexstring: string): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('decodescript', [hexstring])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async estimateSmartFee(blocks: number, estimateMode = 'CONSERVATIVE'): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('estimatesmartfee', [blocks, estimateMode]);
-    return res.result;
+  async estimateSmartFee(blocks: number, estimateMode = 'CONSERVATIVE'): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('estimatesmartfee', [blocks, estimateMode])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getBestBlockHash(): Promise<string> {
-    const res = await this.rpcCall<JsonRpcResponse>('getbestblockhash');
-    return res.result;
+  async getBestBlockHash(): Promise<ResponseDto<string>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getbestblockhash')
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getBlock(hashOrHeight: string, verbose: 0 | 1 | 2 = 1): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getblock', [hashOrHeight, verbose]);
-    return res.result;
+  async getBlock(hashOrHeight: string, verbose: 0 | 1 | 2 = 1): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getblock', [hashOrHeight, verbose])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getBlockChainInfo(): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getblockchaininfo');
-    return res.result;
+  async getBlockChainInfo(): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getblockchaininfo')
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getBlockCount(): Promise<number> {
-    const res = await this.rpcCall<JsonRpcResponse>('getblockcount');
-    return res.result;
+  async getBlockCount(): Promise<ResponseDto<number>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getblockcount')
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getBlockHash(height: number): Promise<string> {
-    const res = await this.rpcCall<JsonRpcResponse>('getblockhash', [height]);
-    return res.result;
+  async getBlockHash(height: number): Promise<ResponseDto<string>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getblockhash', [height])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getBlockHeader(hash: string, verbose = true): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getblockheader', [hash, verbose]);
-    return res.result;
+  async getBlockHeader(hash: string, verbose = true): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getblockheader', [hash, verbose])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getBlockStats(hash: string): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getblockstats', [hash]);
-    return res.result;
+  async getBlockStats(hash: string): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getblockstats', [hash])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getChainTips(): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getchaintips');
-    return res
+  async getChainTips(): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getchaintips')
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getDifficulty(): Promise<number> {
-    const res = await this.rpcCall<JsonRpcResponse>('getdifficulty');
-    return res.result;
+  async getDifficulty(): Promise<ResponseDto<number>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getdifficulty')
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getMempoolAncestors(txId: string, verbose = false): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getmempoolancestors', [txId, verbose]);
-    return res.result;
+  async getMempoolAncestors(txId: string, verbose = false): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getmempoolancestors', [txId, verbose])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getMempoolDescendants(txId: string, verbose = false): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getmempooldescendants', [txId, verbose]);
-    return res.result;
+  async getMempoolDescendants(txId: string, verbose = false): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getmempooldescendants', [txId, verbose])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getMempoolEntry(txId: string): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getmempoolentry', [txId]);
-    return res.result;
+  async getMempoolEntry(txId: string): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getmempoolentry', [txId])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getMempoolInfo(): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getmempoolinfo');
-    return res.result;
+  async getMempoolInfo(): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getmempoolinfo')
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getRawMemPool(verbose = false): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getrawmempool', [verbose]);
-    return res.result;
+  async getRawMemPool(verbose = false): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getrawmempool', [verbose])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getRawTransaction(txId: string, verbose = false): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('getrawtransaction', [txId, verbose]);
-    return res.result;
+  async getRawTransaction(txId: string, verbose = false): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('getrawtransaction', [txId, verbose])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getTxOut(txId: string, index: number, includeMempool = true): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('gettxout', [txId, index, includeMempool]);
-    return res.result;
+  async getTxOut(txId: string, index: number, includeMempool = true): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('gettxout', [txId, index, includeMempool])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async getTxOutProof(txIds: string[], blockhash?: string): Promise<any> {
-    const params: unknown[] = [txIds];
+  async getTxOutProof(txIds: string[], blockhash?: string): Promise<ResponseDto<any>> {
+    const params: unknown[] = [txIds]
     if (blockhash) {
-      params.push(blockhash);
+      params.push(blockhash)
     }
-    const res = await this.rpcCall<JsonRpcResponse>('gettxoutproof', params);
-    return res.result;
+    const res = await this.rpcCall<JsonRpcResponse>('gettxoutproof', params)
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async sendRawTransaction(hexstring: string): Promise<string> {
-    const res = await this.rpcCall<JsonRpcResponse>('sendrawtransaction', [hexstring]);
-    return res.result;
+  async sendRawTransaction(hexstring: string): Promise<ResponseDto<string>> {
+    const res = await this.rpcCall<JsonRpcResponse>('sendrawtransaction', [hexstring])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async validateAddress(address: string): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('validateaddress', [address]);
-    return res.result;
+  async validateAddress(address: string): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('validateaddress', [address])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async verifyMessage(address: string, signature: string, message: string): Promise<boolean> {
-    const res = await this.rpcCall<JsonRpcResponse>('verifymessage', [address, signature, message]);
-    return res.result;
+  async verifyMessage(address: string, signature: string, message: string): Promise<ResponseDto<boolean>> {
+    const res = await this.rpcCall<JsonRpcResponse>('verifymessage', [address, signature, message])
+    return ResponseUtils.fromRpcResult(res)
   }
 
-  async verifyTxOutProof(proof: string): Promise<any> {
-    const res = await this.rpcCall<JsonRpcResponse>('verifytxoutproof', [proof]);
-    return res.result;
+  async verifyTxOutProof(proof: string): Promise<ResponseDto<any>> {
+    const res = await this.rpcCall<JsonRpcResponse>('verifytxoutproof', [proof])
+    return ResponseUtils.fromRpcResult(res)
   }
 }
-

--- a/src/service/walletProvider/metaMask.ts
+++ b/src/service/walletProvider/metaMask.ts
@@ -1,12 +1,15 @@
-import { Container, Service } from 'typedi'
-import { CONFIG, Constant, Utils } from '../../util'
-import { TxPayload } from '../../dto'
 import { BigNumber } from 'bignumber.js'
-import { TatumConfig } from '../tatum'
-import { EvmBasedRpc } from '../rpc'
+import { Container, Service } from 'typedi'
 import { TatumConnector } from '../../connector/tatum.connector'
-import { CreateErc1155NftCollection, CreateFungibleToken, CreateNftCollection } from '../../dto/walletProvider'
-
+import { TxPayload } from '../../dto'
+import {
+  CreateErc1155NftCollection,
+  CreateFungibleToken,
+  CreateNftCollection,
+} from '../../dto/walletProvider'
+import { CONFIG, Constant, Utils } from '../../util'
+import { EvmBasedRpc } from '../rpc'
+import { TatumConfig } from '../tatum'
 
 @Service({
   factory: (data: { id: string }) => {
@@ -42,7 +45,7 @@ export class MetaMask<T extends EvmBasedRpc> {
       const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' })
       return accounts[0] as string
     } catch (error) {
-      console.error('User denied account access:', error);
+      console.error('User denied account access:', error)
       throw new Error(`User denied account access. Error is ${error}`)
     }
   }
@@ -57,7 +60,9 @@ export class MetaMask<T extends EvmBasedRpc> {
     const payload: TxPayload = {
       to: recipient,
       from: await this.connect(),
-      value: `0x${new BigNumber(amount).multipliedBy(10 ** Constant.DECIMALS[this.config.network]).toString(16)}`,
+      value: `0x${new BigNumber(amount)
+        .multipliedBy(10 ** Constant.DECIMALS[this.config.network])
+        .toString(16)}`,
     }
     try {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -68,7 +73,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
@@ -81,11 +86,14 @@ export class MetaMask<T extends EvmBasedRpc> {
    * @param tokenAddress address of the token contract
    */
   async transferErc20(recipient: string, amount: string, tokenAddress: string): Promise<string> {
-    const decimals = await this.rpc.getTokenDecimals(tokenAddress)
+    const { data: decimals } = await this.rpc.getTokenDecimals(tokenAddress)
     const payload: TxPayload = {
       to: tokenAddress,
       from: await this.connect(),
-      data: `0xa9059cbb${Utils.padWithZero(recipient)}${new BigNumber(amount).multipliedBy(10 ** decimals.toNumber()).toString(16).padStart(64, '0')}`,
+      data: `0xa9059cbb${Utils.padWithZero(recipient)}${new BigNumber(amount)
+        .multipliedBy(10 ** decimals.toNumber())
+        .toString(16)
+        .padStart(64, '0')}`,
     }
     try {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -96,7 +104,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
@@ -128,7 +136,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
@@ -144,14 +152,16 @@ export class MetaMask<T extends EvmBasedRpc> {
       path: `contract/deploy/prepare`,
       body: {
         contractType: 'fungible',
-        params: [body.name,
+        params: [
+          body.name,
           body.symbol,
           decimals,
           `0x${new BigNumber(body.initialSupply).multipliedBy(10 ** decimals).toString(16)}`,
           body.initialHolder || from,
           body.admin || from,
           body.minter || from,
-          body.pauser || from],
+          body.pauser || from,
+        ],
       },
     })
     const payload: TxPayload = {
@@ -167,7 +177,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
@@ -199,7 +209,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
@@ -216,7 +226,9 @@ export class MetaMask<T extends EvmBasedRpc> {
     const payload: TxPayload = {
       to: tokenAddress,
       from: from,
-      data: `0x42842e0e${Utils.padWithZero(from)}${Utils.padWithZero(recipient)}${new BigNumber(tokenId).toString(16).padStart(64, '0')}`,
+      data: `0x42842e0e${Utils.padWithZero(from)}${Utils.padWithZero(recipient)}${new BigNumber(tokenId)
+        .toString(16)
+        .padStart(64, '0')}`,
     }
     try {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -227,7 +239,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
@@ -240,11 +252,14 @@ export class MetaMask<T extends EvmBasedRpc> {
    * @param tokenAddress address of the token contract
    */
   async approveErc20(spender: string, amount: string, tokenAddress: string): Promise<string> {
-    const decimals = await this.rpc.getTokenDecimals(tokenAddress)
+    const { data: decimals } = await this.rpc.getTokenDecimals(tokenAddress)
     const payload: TxPayload = {
       to: tokenAddress,
       from: await this.connect(),
-      data: `0x095ea7b3${Utils.padWithZero(spender)}${new BigNumber(amount).multipliedBy(10 ** decimals.toNumber()).toString(16).padStart(64, '0')}`,
+      data: `0x095ea7b3${Utils.padWithZero(spender)}${new BigNumber(amount)
+        .multipliedBy(10 ** decimals.toNumber())
+        .toString(16)
+        .padStart(64, '0')}`,
     }
     try {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -255,7 +270,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
@@ -276,7 +291,7 @@ export class MetaMask<T extends EvmBasedRpc> {
         params: [payload],
       })
     } catch (e) {
-      console.error('User denied transaction signature:', e);
+      console.error('User denied transaction signature:', e)
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -1,3 +1,5 @@
+import { JsonRpcResponse } from '../dto'
+
 export enum Status {
   SUCCESS = 'SUCCESS',
   ERROR = 'ERROR',
@@ -82,5 +84,27 @@ export const ErrorUtils = {
       'message' in e &&
       typeof (e as Record<string, unknown>).message === 'string'
     )
+  },
+}
+
+export const ResponseUtils = {
+  fromRpcResult: <T>(response: JsonRpcResponse): ResponseDto<T> => {
+    if (response && response.result) {
+      return {
+        data: response.result,
+        status: Status.SUCCESS,
+      }
+    } else if (response && response.error) {
+      return {
+        data: null as unknown as T,
+        status: Status.ERROR,
+        error: ErrorUtils.toErrorWithMessage(response.error),
+      }
+    }
+    return {
+      data: null as unknown as T,
+      status: Status.ERROR,
+      error: ErrorUtils.toErrorWithMessage('Internal error'),
+    }
   },
 }


### PR DESCRIPTION
# Description

Change all RPC methods to return a ResponseDto object with fields: data, status, error. In that way user can get more information about errors if the call fails. This is a breaking change as the actual result of the RPC call will be in the `data` field.


## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
