### PR TITLE
fix optional blockNumber property in eth_getTransactionCount

### DIFF
--- a/src/service/rpc/evm/AbstractEvmBasedRpc.ts
+++ b/src/service/rpc/evm/AbstractEvmBasedRpc.ts
@@ -277,7 +277,7 @@ export abstract class AbstractEvmBasedRpc implements EvmBasedRpcInterface {
     return ResponseUtils.fromRpcResult(r)
   }
 
-  async getTransactionCount(address: string, blockNumber?: BlockNumber): Promise<ResponseDto<BigNumber>> {
+  async getTransactionCount(address: string, blockNumber: BlockNumber = 'latest'): Promise<ResponseDto<BigNumber>> {
     const r = await this.rpcCall<JsonRpcResponse>('eth_getTransactionCount', [
       address,
       typeof blockNumber === 'number' ? '0x' + new BigNumber(blockNumber).toString(16) : blockNumber,


### PR DESCRIPTION
# Description

Fixed optional block Number property in eth_getTransactionCount. 
Default state chosen as 'latest'. Discussion is welcome.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
