### PR TITLE
Move node-fetch from devDep to Dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [3.0.9] - 2023.08.10
+## [3.0.9] - 2023.08.13
+### Updated
+- Move node-fetch from devDep to Dep to enable package usage in Node.js apps
+
+## [3.0.8] - 2023.08.10
 ### Updated
 - Add better logging message
 - Updated contributing guide

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   "dependencies": {
     "bignumber.js": "^9.1.1",
     "reflect-metadata": "^0.1.13",
-    "typedi": "^0.10.0"
+    "typedi": "^0.10.0",
+    "@types/node-fetch": "^2.6.3"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@types/node": "^18.15.11",
-    "@types/node-fetch": "^2.6.3",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",


### PR DESCRIPTION
In Node.js the SDK is not working due to `ReferenceError: fetch is not defined` error