### PR TITLE
ALL-2135 Extend list of urls for SSRF check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.16] - 2023.09.05
+### Updated
+ - Extend allowed list of urls for SSRF check
+
 ## [3.0.15] - 2023.08.30
 ### Updated
  - This commit introduces a Server Side Request Forgery (SSRF) check to the `initRemoteHosts` method within `LoadBalancerRpc.ts`. This check ensures that URLs end with 'rpc.tatum.io' before loading them to avoid potential SSRF attacks. To accommodate this change, `initRemoteHosts` has also been refactored to accept an `InitRemoteHostsParams` object. In addition, an optional parameter `noSSRFCheck` has been added to bypass the SSRF check when necessary.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/service/rpc/generic/LoadBalancerRpc.ts
+++ b/src/service/rpc/generic/LoadBalancerRpc.ts
@@ -272,7 +272,7 @@ export class LoadBalancerRpc implements AbstractRpcInterface {
   }
 
   private checkSSRF(url: string) {
-    return url.endsWith('rpc.tatum.io') || url.endsWith('rpc.tatum.io/')
+    return url.endsWith('rpc.tatum.io') || url.endsWith('rpc.tatum.io/') || url.endsWith('rpc.tatum.io/ethv1')
   }
 
   private initRemoteHosts({ nodeType, nodes, noSSRFCheck }: InitRemoteHostsParams) {


### PR DESCRIPTION
# Description
Extend list of urls for SSRF check. This fixes RPC calls to Horizon EON and Flare


- [x] Bug fix (non-breaking change which fixes an issue)

