### PR TITLE
ALL-2134 - fix rawBatchRpcCall return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.20] - 2023.09.08
+### Fixed
+- fix batched raw RPC call return type to also include method level error
+
 ## [3.0.19] - 2023.09.07
 ### Added
  - Users can access data from the Horizen EON chain by using the `address` submodule. - `address.getTransactions({...})`, `address.getBalance({...})`
@@ -8,7 +12,7 @@
 ## [3.0.17] - 2023.09.06
 ### Added
  - Add functions to EVM rpc interface: getTokenTotalSupply, getTokenCap, supportsInterfaceERC1155
- -
+
 ## [3.0.16] - 2023.09.05
 ### Updated
  - Extend allowed list of urls for SSRF check

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/dto/rpc/AbstractJsonRpcInterface.ts
+++ b/src/dto/rpc/AbstractJsonRpcInterface.ts
@@ -4,6 +4,6 @@ import { JsonRpcResponse } from '../JsonRpcResponse.dto'
 
 export interface AbstractRpcInterface {
   rawRpcCall(body: JsonRpcCall): Promise<JsonRpcResponse<any>>
-  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]>
+  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>>
   destroy(): void
 }

--- a/src/service/address/address.ts
+++ b/src/service/address/address.ts
@@ -433,8 +433,12 @@ export class Address {
         .rawBatchRpcCall(
           addresses.map((a, i) => Utils.prepareRpcCall('getBalance', [a, { commitment: 'processed' }], i)),
         )
-        .then((r) =>
-          r.map((e) => new BigNumber(e.result.value).dividedBy(10 ** Constant.DECIMALS[network]).toString()),
+        .then((r) =>{
+          if(Array.isArray(r)){
+            return r.map((e) => new BigNumber(e.result.value).dividedBy(10 ** Constant.DECIMALS[network]).toString())
+          }
+          return [new BigNumber(r.result.value).dividedBy(10 ** Constant.DECIMALS[network]).toString()]
+        }
         )
     } else if ([Network.XRP, Network.XRP_TESTNET].includes(network)) {
       if (addresses.length !== 1) {

--- a/src/service/rpc/evm/EvmArchiveLoadBalancerRpc.ts
+++ b/src/service/rpc/evm/EvmArchiveLoadBalancerRpc.ts
@@ -94,7 +94,7 @@ export class EvmArchiveLoadBalancerRpc extends AbstractEvmRpc implements EvmBase
     return this.loadBalancerRpc.rawRpcCall(body, isArchive)
   }
 
-  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]> {
+  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>> {
     return this.loadBalancerRpc.rawBatchRpcCall(body)
   }
 

--- a/src/service/rpc/evm/EvmLoadBalancerRpc.ts
+++ b/src/service/rpc/evm/EvmLoadBalancerRpc.ts
@@ -28,7 +28,7 @@ export class EvmLoadBalancerRpc extends AbstractEvmRpc implements EvmBasedRpcSui
     return this.loadBalancerRpc.rawRpcCall(body)
   }
 
-  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]> {
+  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>> {
     return this.loadBalancerRpc.rawBatchRpcCall(body)
   }
 

--- a/src/service/rpc/evm/EvmRpc.ts
+++ b/src/service/rpc/evm/EvmRpc.ts
@@ -28,7 +28,7 @@ export class EvmRpc extends AbstractEvmRpc {
     return (await this.genericRpc.rawRpcCall(body)) as T
   }
 
-  async rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]> {
+  async rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>> {
     return this.genericRpc.rawBatchRpcCall(body)
   }
 

--- a/src/service/rpc/generic/AbstractBatchRpc.ts
+++ b/src/service/rpc/generic/AbstractBatchRpc.ts
@@ -30,7 +30,7 @@ export abstract class AbstractBatchRpc implements AbstractRpcInterface {
     return this.connector.rpcCall(this.getRpcNodeUrl(), body)
   }
 
-  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]> {
+  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>> {
     return this.connector.rpcCall(this.getRpcNodeUrl(), body)
   }
 

--- a/src/service/rpc/generic/LoadBalancerRpc.ts
+++ b/src/service/rpc/generic/LoadBalancerRpc.ts
@@ -431,7 +431,7 @@ export class LoadBalancerRpc implements AbstractRpcInterface {
     }
   }
 
-  async rawBatchRpcCall(rpcCall: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]> {
+  async rawBatchRpcCall(rpcCall: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>> {
     const { url, type } = this.getActiveArchiveUrlWithFallback()
     try {
       return await this.connector.rpcCall(url, rpcCall)

--- a/src/service/rpc/utxo/UtxoLoadBalancerRpc.ts
+++ b/src/service/rpc/utxo/UtxoLoadBalancerRpc.ts
@@ -28,7 +28,7 @@ export class UtxoLoadBalancerRpc extends AbstractUtxoRpc implements UtxoBasedRpc
     return this.loadBalancerRpc.rawRpcCall(body)
   }
 
-  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]> {
+  rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>> {
     return this.loadBalancerRpc.rawBatchRpcCall(body)
   }
 

--- a/src/service/rpc/utxo/UtxoRpc.ts
+++ b/src/service/rpc/utxo/UtxoRpc.ts
@@ -24,7 +24,7 @@ export class UtxoRpc extends AbstractUtxoRpc implements UtxoBasedRpcSuite {
     return (await this.genericRpc.rawRpcCall(preparedCall)) as T
   }
 
-  async rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[]> {
+  async rawBatchRpcCall(body: JsonRpcCall[]): Promise<JsonRpcResponse<any>[] | JsonRpcResponse<any>> {
     return this.genericRpc.rawBatchRpcCall(body)
   }
 


### PR DESCRIPTION
In case of top-level error actually a JsonRpcResponse<any> is returned (not array). Eg. 'method not found'