### PR TITLE
ALL-2835 - extension lifetime management methods made optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.0.1] - 2023.09.27
+### Added
+- Extension lifetime management methods made optional to implement.
+- Extension lifetime management method destroy() made async and awaited.
+
+### Changed
+- **[BREAKING CHANGE]** `tatumSdk.destroy(): void` was replaced with `tatumSdk.destroy(): Promise<void>`.
+
 ## [4.0.0] - 2023.09.25
 ### Added
 - Leveraging Extension Ecosystem a specialised Wallet Provider type of extensions was added.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ import { TatumSDK, Network, Ethereum } from '@tatumio/tatum'
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM })
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [Get started documentation](https://docs.tatum.io/sdk/javascript-typescript-sdk).
@@ -222,7 +222,7 @@ const { result } = await tatum.rpc.getBalance('0x742d35Cc6634C0532925a3b844Bc454
 console.log(`Balance: ${data}`)
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 For more details, check out the [RPC documentation](https://docs.tatum.io/docs/rpc).
 
@@ -245,7 +245,7 @@ console.log(response)
 // 🎉  Now your address is subscribed for any events!
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [Notifications documentation](https://docs.tatum.io/docs/notifications).
@@ -266,7 +266,7 @@ const balances: NftAddressBalance[] = await tatum.nft.getBalance({
 console.log(balances)
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [NFTs documentation](https://docs.tatum.io/docs/nfts).
@@ -289,7 +289,7 @@ const txId: string = await tatum.walletProvider.use(MetaMask).transferNative(
 console.log(txId)
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [Wallet Provider documentation](https://docs.tatum.io/docs/wallet-provider).
@@ -308,7 +308,7 @@ const res = await tatum.rates.getCurrentRate('BTC', 'EUR')
 console.log(res.data)
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [Exchange Rates documentation](https://docs.tatum.io/docs/exchange-rates).
@@ -333,7 +333,7 @@ const result = await tatum.fee.getCurrentFee()
 console.log(result.data)
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [Fee Estimation documentation](https://docs.tatum.io/docs/fee-estimation).
@@ -354,7 +354,7 @@ const { data: balances } = await tatum.token.getBalance({
 console.log(balances)
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [Fungible Tokens documentation](https://docs.tatum.io/docs/fungible-tokens).
@@ -374,7 +374,7 @@ const { data: txs } = await tatum.address.getTransactions({
 console.log(txs);
 
 // Destroy Tatum SDK - needed for stopping background jobs
-tatum.destroy()
+await tatum.destroy()
 ```
 
 For more details, check out the [Wallet address operations documentation](https://docs.tatum.io/docs/wallet-address-operations).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/e2e/e2e.util.ts
+++ b/src/e2e/e2e.util.ts
@@ -89,7 +89,7 @@ export const e2eUtil = {
       expect(error).toBeUndefined()
       expect(data.address.toLowerCase()).toEqual(address.toLowerCase())
       expect(url).toBeDefined()
-      tatum.destroy()
+      await tatum.destroy()
       return data.id
     },
     testContractBasedSubscription: async (
@@ -119,7 +119,7 @@ export const e2eUtil = {
       expect(error).toBeUndefined()
       expect(data.contractAddress.toLowerCase()).toEqual(contractAddress.toLowerCase())
       expect(url).toBeDefined()
-      tatum.destroy()
+      await tatum.destroy()
     },
     testBlockBasedSubscription: async (
       tatum: BaseEvmClass,
@@ -136,7 +136,7 @@ export const e2eUtil = {
       expect(error).toBeUndefined()
       expect(data.id).toBeDefined()
       expect(url).toBeDefined()
-      tatum.destroy()
+      await tatum.destroy()
     },
   },
   isVerbose: process.env.E2E_VERBOSE === 'true',

--- a/src/e2e/extensions/e2e.extensions.ts
+++ b/src/e2e/extensions/e2e.extensions.ts
@@ -18,8 +18,9 @@ export class TestExtension extends TatumSdkExtension {
         return Promise.resolve(undefined)
     }
 
-    destroy(): void {
+    destroy(): Promise<void> {
         this.mockTestExtension.destroy()
+        return Promise.resolve(undefined)
     }
 }
 
@@ -42,8 +43,9 @@ export class TestWalletProvider extends TatumSdkWalletProvider<string, string> {
         return Promise.resolve(undefined)
     }
 
-    destroy(): void {
+    destroy(): Promise<void> {
         this.mockTestExtension.destroy()
+        return Promise.resolve(undefined)
     }
 
     signAndBroadcast(payload: string): Promise<TxId> {

--- a/src/e2e/extensions/tatum.extensions.spec.ts
+++ b/src/e2e/extensions/tatum.extensions.spec.ts
@@ -23,7 +23,7 @@ describe('Tatum Extension Ecosystem', () => {
 
       await tatum.extension(TestExtension).sayHello()
 
-      tatum.destroy()
+      await tatum.destroy()
 
       expect(mockTestExtension.dummyMethod).toHaveBeenCalled()
       expect(mockTestExtension.init).toHaveBeenCalled()
@@ -45,7 +45,7 @@ describe('Tatum Extension Ecosystem', () => {
 
       await tatum.walletProvider.use(TestWalletProvider).signAndBroadcast('payload')
 
-      tatum.destroy()
+      await tatum.destroy()
 
       expect(result).toBe('connected')
       expect(mockTestExtension.init).toHaveBeenCalled()

--- a/src/e2e/rpc/evm/evm.e2e.utils.ts
+++ b/src/e2e/rpc/evm/evm.e2e.utils.ts
@@ -24,7 +24,7 @@ export const EvmE2eUtils = {
       const tatum = await EvmE2eUtils.initTatum(network, apiKey)
       const { result } = await tatum.rpc.blockNumber()
 
-      tatum.destroy()
+      await tatum.destroy()
       expect(result?.toNumber()).toBeGreaterThan(0)
     })
 
@@ -45,7 +45,7 @@ export const EvmE2eUtils = {
           value: '0x0',
         }
         const { result } = await tatum.rpc.estimateGas(estimateGas)
-        tatum.destroy()
+        await tatum.destroy()
         expect(result?.toNumber()).toBeGreaterThanOrEqual(0)
       })
     }
@@ -54,7 +54,7 @@ export const EvmE2eUtils = {
       const tatum = await EvmE2eUtils.initTatum(network, apiKey)
       const { result } = await tatum.rpc.gasPrice()
 
-      tatum.destroy()
+      await tatum.destroy()
       expect(result?.toNumber()).toBeGreaterThan(0)
     })
 
@@ -62,7 +62,7 @@ export const EvmE2eUtils = {
       const tatum = await EvmE2eUtils.initTatum(network, apiKey)
       const { result } = await tatum.rpc.clientVersion()
 
-      tatum.destroy()
+      await tatum.destroy()
       expect(result).toBeTruthy()
     })
 
@@ -70,7 +70,7 @@ export const EvmE2eUtils = {
       const tatum = await EvmE2eUtils.initTatum(network, apiKey)
       const { result } = await tatum.rpc.blockNumber()
       const { result: block } = await tatum.rpc.getBlockByNumber((result as BigNumber).toNumber() - 1000)
-      tatum.destroy()
+      await tatum.destroy()
       expect(block.timestamp).toBeDefined()
       expect(block.size).toBeDefined()
     })

--- a/src/e2e/rpc/evm/tatum.rpc.ethereum.spec.ts
+++ b/src/e2e/rpc/evm/tatum.rpc.ethereum.spec.ts
@@ -6,7 +6,7 @@ describe('Ethereum', () => {
   it('should get token total supply', async () => {
     const tatum = await EvmE2eUtils.initTatum(Network.ETHEREUM, process.env.V4_API_KEY_MAINNET)
     const { result } = await tatum.rpc.getTokenTotalSupply('0xdac17f958d2ee523a2206206994597c13d831ec7')
-    tatum.destroy()
+    await tatum.destroy()
     expect(result).toBeDefined()
     expect(result?.isGreaterThan(1))
   })
@@ -14,7 +14,7 @@ describe('Ethereum', () => {
   it('should get token cap', async () => {
     const tatum = await EvmE2eUtils.initTatum(Network.ETHEREUM, process.env.V4_API_KEY_MAINNET)
     const { result } = await tatum.rpc.getTokenCap('0x43044f861ec040DB59A7e324c40507adDb673142')
-    tatum.destroy()
+    await tatum.destroy()
     expect(result).toBeDefined()
     expect(result?.isGreaterThan(1))
   })
@@ -22,7 +22,7 @@ describe('Ethereum', () => {
   it('should return true if contract is a multitoken', async () => {
     const tatum = await EvmE2eUtils.initTatum(Network.ETHEREUM, process.env.V4_API_KEY_MAINNET)
     const { result } = await tatum.rpc.supportsInterfaceERC1155('0xF4Dd946D1406e215a87029db56C69e1Bcf3e1773')
-    tatum.destroy()
+    await tatum.destroy()
     expect(result).toBeDefined()
     expect(result).toBeTruthy()
   })
@@ -43,7 +43,7 @@ describe('Ethereum', () => {
       },
     })
     const { result } = await tatum.rpc.chainId()
-    tatum.destroy()
+    await tatum.destroy()
     expect(result?.toNumber()).toBe(1)
   })
 
@@ -57,7 +57,7 @@ describe('Ethereum', () => {
       '1',
     )
 
-    tatum.destroy()
+    await tatum.destroy()
 
     console.log(result)
   })
@@ -70,6 +70,6 @@ describe('Ethereum', () => {
     )
 
     expect(result.result).toStrictEqual([])
-    tatum.destroy()
+    await tatum.destroy()
   })
 })

--- a/src/e2e/rpc/tatum.rpc.tron.spec.ts
+++ b/src/e2e/rpc/tatum.rpc.tron.spec.ts
@@ -19,21 +19,21 @@ describe('RPCs', () => {
         const tatum = await getTronRpc(true)
         const result = await tatum.rpc.getNowBlock()
         expect(result.block_header.raw_data.number).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getChainParameters', async () => {
         const tatum = await getTronRpc(true)
         const result = await tatum.rpc.getChainParameters()
         expect(result.chainParameter.length).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getBlockByNum', async () => {
         const tatum = await getTronRpc(true)
         const result = await tatum.rpc.getBlock('1000000')
         expect(result.block_header.raw_data.number).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getBlockById', async () => {
@@ -42,7 +42,7 @@ describe('RPCs', () => {
           '00000000000f424013e51b18e0782a32fa079ddafdb2f4c343468cf8896dc887',
         )
         expect(result.block_header.raw_data.number).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getTransactionById', async () => {
@@ -51,7 +51,7 @@ describe('RPCs', () => {
           '7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc',
         )
         expect(result.txID).toBe('7c2d4206c03a883dd9066d620335dc1be272a8dc733cfa3f6d10308faa37facc')
-        tatum.destroy()
+        await tatum.destroy()
       })
     })
     describe('mainnet', () => {
@@ -59,21 +59,21 @@ describe('RPCs', () => {
         const tatum = await getTronRpc(false)
         const result = await tatum.rpc.getNowBlock()
         expect(result.block_header.raw_data.number).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getChainParameters', async () => {
         const tatum = await getTronRpc(false)
         const result = await tatum.rpc.getChainParameters()
         expect(result.chainParameter.length).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getBlockByNum', async () => {
         const tatum = await getTronRpc(false)
         const result = await tatum.rpc.getBlock('51173114')
         expect(result.block_header.raw_data.number).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getBlockById', async () => {
@@ -82,7 +82,7 @@ describe('RPCs', () => {
           '00000000030cd6faf6c282df598285c51bd61e108f98e90ea8a0ef4bd0b2d9ec',
         )
         expect(result.block_header.raw_data.number).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getTransactionById', async () => {
@@ -91,7 +91,7 @@ describe('RPCs', () => {
           'eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598',
         )
         expect(result.txID).toBe('eb49c1c052fb23a9b909a0f487602459112d1fb41276361752e9bc491e649598')
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getBlockByLimitNext', async () => {
@@ -99,7 +99,7 @@ describe('RPCs', () => {
         const result = await tatum.rpc.getBlockByLimitNext(1, 5)
         expect(result.block).toHaveLength(4)
         expect(result.block[0].block_header.raw_data.number).toBeGreaterThan(0)
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('getAccountBalance', async () => {
@@ -126,7 +126,7 @@ describe('RPCs', () => {
             number: 51723491,
           },
         })
-        tatum.destroy()
+        await tatum.destroy()
       })
     })
   })

--- a/src/e2e/rpc/utxo/tatum.rpc.doge.spec.ts
+++ b/src/e2e/rpc/utxo/tatum.rpc.doge.spec.ts
@@ -18,7 +18,7 @@ describe('Doge', () => {
       )
 
       expect(result.result).not.toBeNull()
-      tatum.destroy()
+      await tatum.destroy()
     })
   })
 })

--- a/src/e2e/rpc/utxo/utxo.e2e.utils.ts
+++ b/src/e2e/rpc/utxo/utxo.e2e.utils.ts
@@ -20,7 +20,7 @@ export const UtxoE2eUtils = {
       const { result } = await tatum.rpc.getBlockChainInfo()
 
       expect(result.chain).toBe(type)
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('chain info raw call', async () => {
@@ -31,7 +31,7 @@ export const UtxoE2eUtils = {
         jsonrpc: '2.0',
       })
       expect(info.result.chain).toBe(type)
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('best block hash', async () => {
@@ -39,7 +39,7 @@ export const UtxoE2eUtils = {
       const { result } = await tatum.rpc.getBestBlockHash()
 
       expect(result).toBeTruthy()
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('block count', async () => {
@@ -47,7 +47,7 @@ export const UtxoE2eUtils = {
       const { result } = await tatum.rpc.getBlockCount()
 
       expect(result).toBeGreaterThan(0)
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('difficulty', async () => {
@@ -55,7 +55,7 @@ export const UtxoE2eUtils = {
       const { result } = await tatum.rpc.getDifficulty()
 
       expect(result).toBeGreaterThan(0)
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('mempool info', async () => {
@@ -63,7 +63,7 @@ export const UtxoE2eUtils = {
       const { result } = await tatum.rpc.getMempoolInfo()
 
       expect(result).toBeDefined()
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('estimatesmartfee', async () => {
@@ -71,7 +71,7 @@ export const UtxoE2eUtils = {
       const result = await tatum.rpc.estimateSmartFee(6)
 
       expect(result.result).not.toBeNull()
-      tatum.destroy()
+      await tatum.destroy()
     })
   },
 }

--- a/src/e2e/tatum.address.spec.ts
+++ b/src/e2e/tatum.address.spec.ts
@@ -28,7 +28,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -105,7 +105,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -131,7 +131,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -157,7 +157,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -183,7 +183,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -231,7 +231,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -305,7 +305,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance with native and erc20 assets', async () => {
@@ -343,7 +343,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get balance from eon network', async () => {
@@ -364,7 +364,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get transactions - native only', async () => {
@@ -675,7 +675,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        await tatum.destroy()
+        tatum.destroy()
       })
 
       it('should get transactions - native only', async () => {

--- a/src/e2e/tatum.address.spec.ts
+++ b/src/e2e/tatum.address.spec.ts
@@ -28,7 +28,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -105,7 +105,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -131,7 +131,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -157,7 +157,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -183,7 +183,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -231,7 +231,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance with native assets only', async () => {
@@ -305,7 +305,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance with native and erc20 assets', async () => {
@@ -343,7 +343,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get balance from eon network', async () => {
@@ -364,7 +364,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get transactions - native only', async () => {
@@ -470,7 +470,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(async () => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get transactions', async () => {
@@ -516,7 +516,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(async () => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get transactions', async () => {
@@ -563,7 +563,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(async () => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get transactions', async () => {
@@ -675,7 +675,7 @@ describe.skip('Address', () => {
       })
 
       afterEach(() => {
-        tatum.destroy()
+        await tatum.destroy()
       })
 
       it('should get transactions - native only', async () => {

--- a/src/e2e/tatum.fee.spec.ts
+++ b/src/e2e/tatum.fee.spec.ts
@@ -12,7 +12,7 @@ describe('Fee', () => {
     })
 
     const { data, status } = await tatum.fee.getCurrentFee()
-    tatum.destroy()
+    await tatum.destroy()
     expect(status).toBe(Status.SUCCESS)
     expect(data.gasPrice.fast).toBeDefined()
   })
@@ -26,7 +26,7 @@ describe('Fee', () => {
     })
 
     const { data, status } = await tatum.fee.getCurrentFee()
-    tatum.destroy()
+    await tatum.destroy()
     expect(status).toBe(Status.SUCCESS)
     expect(data.fast).toBeDefined()
   })

--- a/src/e2e/tatum.notification.spec.ts
+++ b/src/e2e/tatum.notification.spec.ts
@@ -333,7 +333,7 @@ describe.skip('notification', () => {
         /^Subscription for type ADDRESS_EVENT on the address id 0xbaf6dc2e647aeb6f510f9e318856a1bcd66c5e19 and currency ETH already exists./,
       )
       expect(error?.code).toEqual('subscription.exists.on.address-and-currency')
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('NOK - invalid address', async () => {
@@ -355,7 +355,7 @@ describe.skip('notification', () => {
         'address must be a valid ETH address. Address must start with 0x and must contain 40 hexadecimal characters after and have the correct checksum. ',
       ])
       expect(error?.code).toEqual('validation.failed')
-      tatum.destroy()
+      await tatum.destroy()
     })
   })
 
@@ -381,7 +381,7 @@ describe.skip('notification', () => {
         (s) => s.network === Network.ETHEREUM && s.address?.toLowerCase() === address.toLowerCase(),
       ) as NotificationSubscription
       expect(subscriptions).toEqual(undefined)
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('NOK - invalid subscription', async () => {
@@ -399,7 +399,7 @@ describe.skip('notification', () => {
       expect((error?.message as object[])[0]).toEqual(
         'id should be valid id and 24 characters long, e.g. 6398ded68bfa23a9709b1b17',
       )
-      tatum.destroy()
+      await tatum.destroy()
     })
   })
 
@@ -421,7 +421,7 @@ describe.skip('notification', () => {
     expect(data[0].url).toBeDefined()
     expect(data[0].type).toBeDefined()
     expect(data.length).toBeGreaterThan(0)
-    tatum.destroy()
+    await tatum.destroy()
   })
 
   // TODO pipeline dont work with this test - IP auth
@@ -443,6 +443,6 @@ describe.skip('notification', () => {
     expect(data[0].timestamp).toBeDefined()
     expect(data[0].failed).toBeDefined()
     expect(data[0].response).toBeDefined()
-    tatum.destroy()
+    await tatum.destroy()
   })
 })

--- a/src/e2e/tatum.rates.spec.ts
+++ b/src/e2e/tatum.rates.spec.ts
@@ -13,7 +13,7 @@ describe('Rates', () => {
   })
 
   afterEach(() => {
-    tatum.destroy()
+    await tatum.destroy()
   })
 
   it('get ETH/EUR', async () => {

--- a/src/e2e/tatum.rates.spec.ts
+++ b/src/e2e/tatum.rates.spec.ts
@@ -13,7 +13,7 @@ describe('Rates', () => {
   })
 
   afterEach(() => {
-    await tatum.destroy()
+    tatum.destroy()
   })
 
   it('get ETH/EUR', async () => {

--- a/src/e2e/tatum.spec.ts
+++ b/src/e2e/tatum.spec.ts
@@ -9,7 +9,7 @@ describe('Tatum Init', () => {
       })
       const { result } = await tatum.rpc.getBlockChainInfo()
       expect(result.chain).toBe('test')
-      tatum.destroy()
+      await tatum.destroy()
     })
 
     it('Mainnet', async () => {
@@ -18,7 +18,7 @@ describe('Tatum Init', () => {
       })
       const { result } = await tatum.rpc.getBlockChainInfo()
       expect(result.chain).toBe('main')
-      tatum.destroy()
+      await tatum.destroy()
     })
   })
 
@@ -37,8 +37,8 @@ describe('Tatum Init', () => {
       const { result: resultTestnet } = await testnet.rpc.getBlockChainInfo()
       expect(resultTestnet.chain).toBe('test')
 
-      testnet.destroy()
-      mainnet.destroy()
+      await testnet.destroy()
+      await mainnet.destroy()
     })
   })
 })

--- a/src/service/extensions/tatumsdk.extensions.dto.ts
+++ b/src/service/extensions/tatumsdk.extensions.dto.ts
@@ -18,8 +18,12 @@ export abstract class TatumSdkExtension {
         protected readonly tatumSdkContainer: ITatumSdkContainer) {
     }
 
-    abstract init(...args: unknown[]): Promise<void>
-    abstract destroy(): void
+    init(): Promise<void> {
+        return Promise.resolve(undefined)
+    }
+    destroy(): Promise<void> {
+        return Promise.resolve(undefined)
+    }
 }
 
 export type ExtensionConstructor = new (tatumSdkContainer: ITatumSdkContainer, ...args: unknown[]) => TatumSdkExtension

--- a/src/service/walletProvider/metaMask/metamask.wallet.provider.ts
+++ b/src/service/walletProvider/metaMask/metamask.wallet.provider.ts
@@ -290,13 +290,4 @@ export class MetaMask extends TatumSdkWalletProvider<string, TxPayload> {
       throw new Error(`User denied transaction signature. Error is ${e}`)
     }
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  destroy(): void {
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  init(..._: unknown[]): Promise<void> {
-    return Promise.resolve(undefined);
-  }
 }


### PR DESCRIPTION
### Added
- Extension lifetime management methods made optional to implement.
- Extension lifetime management method destroy() made async and awaited.

### Changed
- **[BREAKING CHANGE]** `tatumSdk.destroy(): void` was replaced with `tatumSdk.destroy(): Promise<void>`.