### PR TITLE
Rename the "last updated block" field of `NftAddressBalance` to match REST API

### DIFF
--- a/src/service/address/address.dto.ts
+++ b/src/service/address/address.dto.ts
@@ -30,7 +30,7 @@ export interface AddressBalance {
   /**
    * Block number of the last balance update.
    */
-  lastUpdatedBlock?: number
+  lastUpdatedBlockNumber?: number
 }
 
 export interface GetAddressTransactionsQuery {

--- a/src/service/address/address.ts
+++ b/src/service/address/address.ts
@@ -326,8 +326,8 @@ export class Address {
         balance: tokenBalance.balance,
         type: tokenBalance.type,
       }
-      if (tokenBalance.lastUpdatedBlock) {
-        item.lastUpdatedBlock = tokenBalance.lastUpdatedBlock
+      if (tokenBalance.lastUpdatedBlockNumber) {
+        item.lastUpdatedBlockNumber = tokenBalance.lastUpdatedBlockNumber
       }
       if (details[i].symbol) {
         item.asset = details[i].symbol

--- a/src/service/nft/nft.dto.ts
+++ b/src/service/nft/nft.dto.ts
@@ -155,7 +155,7 @@ export interface NftAddressBalance extends NftTokenDetail {
   /**
    * Block number of the last balance update.
    */
-  lastUpdatedBlock: number
+  lastUpdatedBlockNumber: number
 }
 
 export interface GetAllNftTransactionsQuery extends GetAllNftTransactionsQueryDetails {


### PR DESCRIPTION
# Description

Example fix for REST API - SDK naming mismatch.

Fixes https://github.com/tatumio/tatum-js/issues/965

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
