### PR TITLE
ALL-2946 Add faucet submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.1.0] - 2023.10.11
+### Added
+- Added `faucet` submodule with `fund` method for requesting testnet native tokens from available `Tatum` faucets.
+
 ## [4.0.19] - 2023.10.11
 ### Added
 - Updated loadbalancer logging with detailed logs

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ await tatum.destroy()
 For more details, check out the [Wallet address operations documentation](https://docs.tatum.io/docs/wallet-address-operations).
 
 ### Get testnet faucet funds
-Using TatumSDK, you can request testnet token sums of cryptocurrency from our [Faucets](http://faucets.tatum.io).
+Using TatumSDK, you can request testnet native token sums of cryptocurrency from our [Faucets](http://faucets.tatum.io).
 
 ```ts
 import { TatumSDK, Network, Ethereum } from '@tatumio/tatum'

--- a/README.md
+++ b/README.md
@@ -392,10 +392,7 @@ Using TatumSDK, you can request testnet native token sums of cryptocurrency from
 ```ts
 import { TatumSDK, Network, Ethereum } from '@tatumio/tatum'
 
-const tatum = await TatumSDK.init<Ethereum>({
-  network: Network.ETHEREUM_SEPOLIA,
-  version: ApiVersion.V4,
-})
+const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM_SEPOLIA })
 
 const res = await tatum.faucet.fund('0x514d547c8ac8ccbec29b5144810454bd7d3625ca')
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ import { TatumSDK, Network, Ethereum } from '@tatumio/tatum'
 
 const tatum = await TatumSDK.init<Ethereum>({ network: Network.ETHEREUM_SEPOLIA })
 
-const res = await tatum.faucet.fund('0x514d547c8ac8ccbec29b5144810454bd7d3625ca')
+const res = await tatum.faucet.fund('0x712e3a792c974b3e3dbe41229ad4290791c75a82')
 
 if (res.data) {
   console.log(res.data)

--- a/README.md
+++ b/README.md
@@ -397,9 +397,7 @@ const tatum = await TatumSDK.init<Ethereum>({
   version: ApiVersion.V4,
 })
 
-const res = await tatum.faucet.fund({
-  address: '0x514d547c8ac8ccbec29b5144810454bd7d3625ca',
-})
+const res = await tatum.faucet.fund('0x514d547c8ac8ccbec29b5144810454bd7d3625ca')
 
 if (res.data) {
   console.log(res.data);

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Using TatumSDK, you can request testnet native token sums of cryptocurrency from
 ```ts
 import { TatumSDK, Network, Ethereum } from '@tatumio/tatum'
 
-await TatumSDK.init<Ethereum>({
+const tatum = await TatumSDK.init<Ethereum>({
   network: Network.ETHEREUM_SEPOLIA,
   version: ApiVersion.V4,
 })

--- a/README.md
+++ b/README.md
@@ -400,9 +400,9 @@ const tatum = await TatumSDK.init<Ethereum>({
 const res = await tatum.faucet.fund('0x514d547c8ac8ccbec29b5144810454bd7d3625ca')
 
 if (res.data) {
-  console.log(res.data);
+  console.log(res.data)
 } else {
-  console.error(res.error);
+  console.error(res.error)
 }
 
 // Destroy Tatum SDK - needed for stopping background jobs

--- a/README.md
+++ b/README.md
@@ -397,11 +397,15 @@ await TatumSDK.init<Ethereum>({
   version: ApiVersion.V4,
 })
 
-const { txId } = await tatum.faucet.getFaucetFunds({
+const res = await tatum.faucet.fund({
   address: '0x514d547c8ac8ccbec29b5144810454bd7d3625ca',
 })
 
-console.log(txId);
+if (res.data) {
+  console.log(res.data);
+} else {
+  console.error(res.error);
+}
 
 // Destroy Tatum SDK - needed for stopping background jobs
 await tatum.destroy()

--- a/README.md
+++ b/README.md
@@ -386,6 +386,27 @@ await tatum.destroy()
 
 For more details, check out the [Wallet address operations documentation](https://docs.tatum.io/docs/wallet-address-operations).
 
+### Get testnet faucet funds
+Using TatumSDK, you can request testnet token sums of cryptocurrency from our [Faucets](http://faucets.tatum.io).
+
+```ts
+import { TatumSDK, Network, Ethereum } from '@tatumio/tatum'
+
+await TatumSDK.init<Ethereum>({
+  network: Network.ETHEREUM_SEPOLIA,
+  version: ApiVersion.V4,
+})
+
+const { txId } = await tatum.faucet.getFaucetFunds({
+  address: '0x514d547c8ac8ccbec29b5144810454bd7d3625ca',
+})
+
+console.log(txId);
+
+// Destroy Tatum SDK - needed for stopping background jobs
+await tatum.destroy()
+```
+
 ## RPC calls
 All RPC calls are implemented in the `tatum.rpc.*` submodule.
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -14,4 +14,6 @@ TatumSDK is thoughtfully designed and organized into these submodules to provide
 
 * **Rate Exchange submodule - `tatum.rates.*`**: This submodule enables allows you to easily obtain exchange rates for fiat/crypto.
 
+* **Faucet submodule - `tatum.faucet.*`**: This submodule allows you to get testnet faucet funds for all supported chains (http://faucets.tatum.io).
+
 By dividing the library into these submodules, TatumSDK offers an organized, easy-to-use interface that makes interacting with Ethereum and other blockchains a breeze. Both beginners and advanced developers can benefit from the streamlined architecture, enabling them to focus on building powerful blockchain applications.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "4.0.19",
+  "version": "4.1.0",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/e2e/tatum.faucet.spec.ts
+++ b/src/e2e/tatum.faucet.spec.ts
@@ -1,0 +1,43 @@
+import { Ethereum, Network, TatumSDK } from '../service'
+
+describe('Tatum faucet', () => {
+  const SEPOLIA_VAULT = '0x712e3a792c974b3e3dbe41229ad4290791c75a82'
+
+  describe('invalid request', () => {
+    const EXPECTED_RES = 'validation.failed'
+
+    it('should get error due to unsupported chain', async () => {
+      const tatum = await TatumSDK.init<Ethereum>({
+        network: Network.MULTIVERSX,
+      })
+      const res = await tatum.faucet.fund(SEPOLIA_VAULT)
+
+      expect(res.error?.code).toBe(EXPECTED_RES)
+      await tatum.destroy()
+    })
+
+    it('should get error due to unsupported mainnet', async () => {
+      const tatum = await TatumSDK.init<Ethereum>({
+        network: Network.ETHEREUM,
+      })
+      const res = await tatum.faucet.fund(SEPOLIA_VAULT)
+
+      expect(res.error?.code).toBe(EXPECTED_RES)
+      await tatum.destroy()
+    })
+  })
+
+  describe('valid request', () => {
+    const EXPECTED_RES = 'faucet.balance'
+
+    it('should only stop at balance being above limit', async () => {
+      const tatum = await TatumSDK.init<Ethereum>({
+        network: Network.ETHEREUM_SEPOLIA,
+      })
+      const res = await tatum.faucet.fund(SEPOLIA_VAULT)
+
+      expect(res.error?.code).toBe(EXPECTED_RES)
+      await tatum.destroy()
+    })
+  })
+})

--- a/src/e2e/tatum.faucet.spec.ts
+++ b/src/e2e/tatum.faucet.spec.ts
@@ -12,8 +12,8 @@ describe('Tatum faucet', () => {
       })
       const res = await tatum.faucet.fund(SEPOLIA_VAULT)
 
-      expect(res.error?.code).toBe(EXPECTED_RES)
       await tatum.destroy()
+      expect(res.error?.code).toBe(EXPECTED_RES)
     })
 
     it('should get error due to unsupported mainnet', async () => {
@@ -22,8 +22,8 @@ describe('Tatum faucet', () => {
       })
       const res = await tatum.faucet.fund(SEPOLIA_VAULT)
 
-      expect(res.error?.code).toBe(EXPECTED_RES)
       await tatum.destroy()
+      expect(res.error?.code).toBe(EXPECTED_RES)
     })
   })
 
@@ -36,8 +36,8 @@ describe('Tatum faucet', () => {
       })
       const res = await tatum.faucet.fund(SEPOLIA_VAULT)
 
-      expect(res.error?.code).toBe(EXPECTED_RES)
       await tatum.destroy()
+      expect(res.error?.code).toBe(EXPECTED_RES)
     })
   })
 })

--- a/src/service/faucet/faucet.dto.ts
+++ b/src/service/faucet/faucet.dto.ts
@@ -12,12 +12,13 @@ export interface TxIdResponse {
 
 export interface FaucetRequest {
   /**
-   * One of the supported testnet chains
-   */
-  chain: Chain
-
-  /**
    * Address of wallet requesting funds
    */
   address: string
+
+  /**
+   * One of the supported testnet chains
+   * By default it is selected based on network
+   */
+  chain?: Chain
 }

--- a/src/service/faucet/faucet.dto.ts
+++ b/src/service/faucet/faucet.dto.ts
@@ -1,0 +1,23 @@
+export type Chain =
+  | 'ethereum-sepolia'
+  | 'ethereum-holesky'
+  | 'polygon-mumbai'
+  | 'eon-testnet'
+  | 'celo-testnet'
+  | 'bsc-testnet'
+
+export interface TxIdResponse {
+  txId: string
+}
+
+export interface FaucetRequest {
+  /**
+   * One of the supported testnet chains
+   */
+  chain: Chain
+
+  /**
+   * Address of wallet requesting funds
+   */
+  address: string
+}

--- a/src/service/faucet/faucet.dto.ts
+++ b/src/service/faucet/faucet.dto.ts
@@ -1,24 +1,3 @@
-export type FaucetNetwork =
-  | 'ethereum-sepolia'
-  | 'ethereum-holesky'
-  | 'polygon-mumbai'
-  | 'horizen-eon-gobi' // eon-testnet
-  | 'celo-testnet'
-  | 'bsc-testnet'
-
 export interface TxIdResponse {
   txId: string
-}
-
-export interface FaucetRequest {
-  /**
-   * Address of wallet requesting funds
-   */
-  address: string
-
-  /**
-   * One of the supported testnet chains
-   * By default it is selected based on network
-   */
-  chain?: FaucetNetwork
 }

--- a/src/service/faucet/faucet.dto.ts
+++ b/src/service/faucet/faucet.dto.ts
@@ -1,8 +1,8 @@
-export type Chain =
+export type FaucetNetwork =
   | 'ethereum-sepolia'
   | 'ethereum-holesky'
   | 'polygon-mumbai'
-  | 'eon-testnet'
+  | 'horizen-eon-gobi' // eon-testnet
   | 'celo-testnet'
   | 'bsc-testnet'
 
@@ -20,5 +20,5 @@ export interface FaucetRequest {
    * One of the supported testnet chains
    * By default it is selected based on network
    */
-  chain?: Chain
+  chain?: FaucetNetwork
 }

--- a/src/service/faucet/faucet.ts
+++ b/src/service/faucet/faucet.ts
@@ -21,7 +21,7 @@ export class Faucet {
     this.config = Container.of(this.id).get(CONFIG)
   }
 
-  async getFaucetFunds({ address, chain }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
+  async fund({ address, chain }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
     const faucetChain = this.convertToFaucetChain(chain || this.config.network)
 
     return ErrorUtils.tryFail(async () => {

--- a/src/service/faucet/faucet.ts
+++ b/src/service/faucet/faucet.ts
@@ -1,7 +1,8 @@
 import { Container, Service } from 'typedi'
 
 import { TatumConnector } from '../../connector/tatum.connector'
-import { ErrorUtils, ResponseDto } from '../../util'
+import { CONFIG, ErrorUtils, ResponseDto } from '../../util'
+import { TatumConfig } from '../tatum'
 
 import { FaucetRequest, TxIdResponse } from './faucet.dto'
 
@@ -12,16 +13,18 @@ import { FaucetRequest, TxIdResponse } from './faucet.dto'
   transient: true,
 })
 export class Faucet {
-  private connector: TatumConnector
+  private readonly connector: TatumConnector
+  private readonly config: TatumConfig
 
   constructor(private readonly id: string) {
     this.connector = Container.of(this.id).get(TatumConnector)
+    this.config = Container.of(this.id).get(CONFIG)
   }
 
-  getCurrentRateBatch({ chain, address }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
+  getFaucetFunds({ address, chain }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
     return ErrorUtils.tryFail(async () => {
       return this.connector.post<TxIdResponse>({
-        path: `faucet/${chain}/${address}`,
+        path: `faucet/${chain || this.config.network}/${address}`,
       })
     })
   }

--- a/src/service/faucet/faucet.ts
+++ b/src/service/faucet/faucet.ts
@@ -1,0 +1,28 @@
+import { Container, Service } from 'typedi'
+
+import { TatumConnector } from '../../connector/tatum.connector'
+import { ErrorUtils, ResponseDto } from '../../util'
+
+import { FaucetRequest, TxIdResponse } from './faucet.dto'
+
+@Service({
+  factory: (data: { id: string }) => {
+    return new Faucet(data.id)
+  },
+  transient: true,
+})
+export class Faucet {
+  private connector: TatumConnector
+
+  constructor(private readonly id: string) {
+    this.connector = Container.of(this.id).get(TatumConnector)
+  }
+
+  getCurrentRateBatch({ chain, address }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
+    return ErrorUtils.tryFail(async () => {
+      return this.connector.post<TxIdResponse>({
+        path: `faucet/${chain}/${address}`,
+      })
+    })
+  }
+}

--- a/src/service/faucet/faucet.ts
+++ b/src/service/faucet/faucet.ts
@@ -4,7 +4,7 @@ import { TatumConnector } from '../../connector/tatum.connector'
 import { CONFIG, ErrorUtils, ResponseDto } from '../../util'
 import { Network, TatumConfig } from '../tatum'
 
-import { FaucetNetwork, FaucetRequest, TxIdResponse } from './faucet.dto'
+import { TxIdResponse } from './faucet.dto'
 
 @Service({
   factory: (data: { id: string }) => {
@@ -21,17 +21,17 @@ export class Faucet {
     this.config = Container.of(this.id).get(CONFIG)
   }
 
-  async fund({ address, chain }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
-    const faucetChain = this.convertToFaucetChain(chain || this.config.network)
+  async fund(address: string): Promise<ResponseDto<TxIdResponse>> {
+    const chain = this.convertToFaucetChain(this.config.network)
 
     return ErrorUtils.tryFail(async () => {
       return this.connector.post<TxIdResponse>({
-        path: `faucet/${faucetChain}/${address}`,
+        path: `faucet/${chain}/${address}`,
       })
     })
   }
 
-  private convertToFaucetChain(network: FaucetNetwork | Network) {
+  private convertToFaucetChain(network: Network) {
     return network === Network.HORIZEN_EON_GOBI ? 'eon-testnet' : network
   }
 }

--- a/src/service/faucet/faucet.ts
+++ b/src/service/faucet/faucet.ts
@@ -2,9 +2,9 @@ import { Container, Service } from 'typedi'
 
 import { TatumConnector } from '../../connector/tatum.connector'
 import { CONFIG, ErrorUtils, ResponseDto } from '../../util'
-import { TatumConfig } from '../tatum'
+import { Network, TatumConfig } from '../tatum'
 
-import { FaucetRequest, TxIdResponse } from './faucet.dto'
+import { FaucetNetwork, FaucetRequest, TxIdResponse } from './faucet.dto'
 
 @Service({
   factory: (data: { id: string }) => {
@@ -21,11 +21,17 @@ export class Faucet {
     this.config = Container.of(this.id).get(CONFIG)
   }
 
-  getFaucetFunds({ address, chain }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
+  async getFaucetFunds({ address, chain }: FaucetRequest): Promise<ResponseDto<TxIdResponse>> {
+    const faucetChain = this.convertToFaucetChain(chain || this.config.network)
+
     return ErrorUtils.tryFail(async () => {
       return this.connector.post<TxIdResponse>({
-        path: `faucet/${chain || this.config.network}/${address}`,
+        path: `faucet/${faucetChain}/${address}`,
       })
     })
+  }
+
+  private convertToFaucetChain(network: FaucetNetwork | Network) {
+    return network === Network.HORIZEN_EON_GOBI ? 'eon-testnet' : network
   }
 }

--- a/src/service/faucet/index.ts
+++ b/src/service/faucet/index.ts
@@ -1,0 +1,2 @@
+export * from './faucet'
+export * from './faucet.dto'

--- a/src/service/tatum/tatum.ts
+++ b/src/service/tatum/tatum.ts
@@ -18,6 +18,7 @@ import {
   TatumSdkContainer,
   TatumSdkExtension,
 } from '../extensions'
+import { Faucet } from '../faucet'
 import { FeeEvm, FeeUtxo } from '../fee'
 import { Nft, NftTezos } from '../nft'
 import { Notification } from '../notification'
@@ -80,6 +81,7 @@ export class BaseTatumSdk extends TatumSdkChain {
   address: Address
   walletProvider: WalletProvider
   rates: Rates
+  faucet: Faucet
 
   constructor(id: string) {
     super(id)
@@ -89,6 +91,7 @@ export class BaseTatumSdk extends TatumSdkChain {
     this.walletProvider = Container.of(id).get(WalletProvider)
     this.address = Container.of(id).get(Address)
     this.rates = Container.of(id).get(Rates)
+    this.faucet = Container.of(id).get(Faucet)
   }
 }
 


### PR DESCRIPTION
### :bookmark_tabs: Overview
Added submodule `faucet` with method `fund` allowing users to request testnet native tokens from available [Tatum faucets](http://faucets.tatum.io).

### :wrench: Changes
:heavy_plus_sign: New feature (non-breaking change which adds functionality)

### :computer: How to Use
To request from the faucet, you'll need to specify the network type when initializing your Tatum SDK instance and call `fund` method with wallet address requesting the funds:
```ts
import { TatumSDK, Network, Ethereum } from '@tatumio/tatum'

const tatum = await TatumSDK.init<Ethereum>({
  network: Network.ETHEREUM_SEPOLIA,
})

const res = await tatum.faucet.fund('0x712e3a792c974b3e3dbe41229ad4290791c75a82')

if (res.data) {
  console.log(res.data)
} else {
  console.error(res.error)
}

// Destroy Tatum SDK - needed for stopping background jobs
await tatum.destroy()
```