### PR TITLE
ALL-2673 Fix debugStorageRangeAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.18] - 2023.10.11
+### Fixed
+- Update debug storage range parameters. The `debugStorageRangeAt` function in the EvmRpc now takes a number instead of a string for the `maxResults` parameter.
+
 ## [4.0.17] - 2023.10.11
 ### Added
 - Added RPC support for the AVALANCHE_C network. Users can now make RPC calls to these network using the `Network.AVALANCHE_C` network.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "4.0.17",
+  "version": "4.0.18",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/dto/rpc/EvmBasedRpcInterface.ts
+++ b/src/dto/rpc/EvmBasedRpcInterface.ts
@@ -158,7 +158,7 @@ export interface EvmBasedRpcInterface {
     txIndex: number,
     contractAddress: string,
     startKey: string,
-    maxResult: string,
+    maxResult: number,
   ): Promise<JsonRpcResponse<any>>
 
   debugTraceCall(

--- a/src/e2e/rpc/evm/tatum.rpc.ethereum.spec.ts
+++ b/src/e2e/rpc/evm/tatum.rpc.ethereum.spec.ts
@@ -49,15 +49,15 @@ describe('Ethereum', () => {
 
   it('debug storage range at', async () => {
     const tatum = await EvmE2eUtils.initTatum(Network.ETHEREUM, process.env.V4_API_KEY_MAINNET)
-    const result = await tatum.rpc.debugStorageRangeAt(
-      '0x76f64c40d6493cf00426be2eecdaf3f968768619bfb21ce6c57921be497ab3f7',
+    const { result } = await tatum.rpc.debugStorageRangeAt(
+      "0xc20f6b582e0c7923341cdb1299a94ea00c8a23e1ccabc532955a2a07b27121dc",
       0,
-      '0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5',
-      '0x0000000000000000000000000000000000000000000000000000000000000000',
-      '1',
+      "0x5799e216fb6825f21e6f20af22836303edc45df3",
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      5
     )
-    expect(result).toBeDefined()
     await tatum.destroy()
+    expect(result).toBeDefined()
   })
 
   it('get logs', async () => {
@@ -66,7 +66,7 @@ describe('Ethereum', () => {
       address: '0xdafea492d9c6733ae3d56b7ed1adb60692c98bc5',
     })
 
-    expect(result.result).toStrictEqual([])
     await tatum.destroy()
+    expect(result.result).toStrictEqual([])
   })
 })

--- a/src/service/rpc/evm/AbstractEvmRpc.ts
+++ b/src/service/rpc/evm/AbstractEvmRpc.ts
@@ -54,7 +54,7 @@ export abstract class AbstractEvmRpc implements EvmBasedRpcInterface {
     txIndex: number,
     contractAddress: string,
     startKey: string,
-    maxResult: string,
+    maxResult: number,
   ): Promise<JsonRpcResponse<any>> {
     return this.rpcCall<JsonRpcResponse<any>>('debug_storageRangeAt', [
       blockHash,


### PR DESCRIPTION
Update debug storage range parameters. The `debugStorageRangeAt` function in the EvmRpc now takes a number instead of a string for the `maxResults` parameter.