### PR TITLE
UTXO `Address.getTransactions` block ranges support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.1.20] - 2023.10.31
+### Fixed
+- Fixed usage of `fromBlock` and `toBlock` params for UTXO-based blockchains in `Address.getTransactions`
+
 ## [4.1.19] - 2023.10.31
 ### Fixed
 - Configurable extension usage typing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "4.1.19",
+  "version": "4.1.20",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/e2e/tatum.address.spec.ts
+++ b/src/e2e/tatum.address.spec.ts
@@ -507,6 +507,25 @@ describe.skip('Address', () => {
           transactionType: 'incoming',
         })
       })
+
+      it('should get transactions by block with cursor pagination', async () => {
+        const txs = await tatum.address.getTransactions({
+          address: 'tb1qrd9jz8ksy3qqm400vt296udlvk89z96p443mv0',
+          fromBlock: 2427335,
+          toBlock: 2427654,
+        })
+        expect(txs.status === Status.SUCCESS)
+        expect(txs.data).toHaveLength(1)
+        expect(txs.data[0]).toStrictEqual({
+          address: 'tb1qrd9jz8ksy3qqm400vt296udlvk89z96p443mv0',
+          amount: '0.01796111',
+          blockNumber: 2427335,
+          chain: 'bitcoin-testnet',
+          hash: 'ea428edd33dbadf1c9fc11320ab8d4cac4a3b52fc5f086ab46c8b02c71b1e53e',
+          timestamp: 1680597327,
+          transactionType: 'outgoing',
+        })
+      })
     })
     describe('getTransactions DOGECOIN', () => {
       let tatum: Dogecoin
@@ -551,6 +570,25 @@ describe.skip('Address', () => {
           chain: 'doge-testnet',
           hash: '7fd8c504d5af06b840fa2a95a256b22bbbc72285d1962daacac097326d4f4450',
           timestamp: 1680110393,
+          transactionType: 'outgoing',
+        })
+      })
+
+      it('should get transactions by block with cursor pagination', async () => {
+        const txs = await tatum.address.getTransactions({
+          address: 'nqNmVv1PCPFbNQLBMbeKhW4YrswqEgpVsr',
+          fromBlock: 4334638,
+          toBlock: 4373217,
+        })
+        expect(txs.status === Status.SUCCESS)
+        expect(txs.data).toHaveLength(1)
+        expect(txs.data[0]).toStrictEqual({
+          address: 'nqNmVv1PCPFbNQLBMbeKhW4YrswqEgpVsr',
+          amount: '2',
+          blockNumber: 4334638,
+          chain: 'doge-testnet',
+          hash: 'b417a1b5ffa6aec9d6f6ba2895876ac9036353efc555bdb660194a5af3b88036',
+          timestamp: 1680110455,
           transactionType: 'outgoing',
         })
       })
@@ -607,6 +645,25 @@ describe.skip('Address', () => {
           hash: '472329bfef53408df028c3689ed31767d52aa5cf4469762dff0f494b2e5d854d',
           timestamp: 1679137321,
           transactionType: 'incoming',
+        })
+      })
+
+      it('should get transactions by block with cursor pagination', async () => {
+        const txs = await tatum.address.getTransactions({
+          address: 'n22dLZeTMRCUpaLMdgDcQzUXJJnfKcsnS3',
+          fromBlock: 2719828,
+          toBlock: 2719829,
+        })
+        expect(txs.status === Status.SUCCESS)
+        expect(txs.data).toHaveLength(1)
+        expect(txs.data[0]).toStrictEqual({
+          address: 'n22dLZeTMRCUpaLMdgDcQzUXJJnfKcsnS3',
+          amount: '0.0009',
+          blockNumber: 2719828,
+          chain: 'litecoin-testnet',
+          hash: '7643cfd74bfd6cea2fc6f2b80ebbe03d3f1673125d445b63f23a32f83d1438c6',
+          timestamp: 1680110627,
+          transactionType: 'outgoing',
         })
       })
     })

--- a/src/service/address/address.ts
+++ b/src/service/address/address.ts
@@ -300,7 +300,16 @@ export class Address {
         // TODO: implement for other networks - TRON, XRP, CARDANO, SOL, XLM etc etc
         throw new Error(`Not supported for ${chain} network.`)
       }
-      return this.processUtxoBasedTxs(path, pageSize, page, transactionDirection, chain, address)
+      return this.processUtxoBasedTxs(
+        path,
+        pageSize,
+        page,
+        transactionDirection,
+        chain,
+        address,
+        fromBlock,
+        toBlock,
+      )
     })
   }
 
@@ -350,6 +359,8 @@ export class Address {
     transactionDirection: 'incoming' | 'outgoing' | undefined,
     chain: Network,
     address: string,
+    fromBlock: number | undefined,
+    toBlock: number | undefined,
   ) {
     return this.connector
       .get<
@@ -367,6 +378,8 @@ export class Address {
           pageSize,
           offset: page * pageSize,
           txType: transactionDirection,
+          blockFrom: fromBlock,
+          blockTo: toBlock,
         },
       })
       .then((r) => {

--- a/src/service/address/address.ts
+++ b/src/service/address/address.ts
@@ -359,8 +359,8 @@ export class Address {
     transactionDirection: 'incoming' | 'outgoing' | undefined,
     chain: Network,
     address: string,
-    fromBlock: number | undefined,
-    toBlock: number | undefined,
+    blockFrom: number | undefined,
+    blockTo: number | undefined,
   ) {
     return this.connector
       .get<
@@ -378,8 +378,8 @@ export class Address {
           pageSize,
           offset: page * pageSize,
           txType: transactionDirection,
-          blockFrom: fromBlock,
-          blockTo: toBlock,
+          blockFrom,
+          blockTo,
         },
       })
       .then((r) => {


### PR DESCRIPTION
# Description

Fixes support for UTXO when using `Address.getTransactions` with block ranges

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
