### PR TITLE
ALL-3334 Fix Tezos address balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.1.23] - 2023.11.6
+### Changed
+- Tezos address balances fixes. Call to `address.getBalance` returns balances of all tokens for a given address. This call accepts only one `address` as a parameter, not an array of addresses.
+
 ## [4.1.22] - 2023.11.2
 ### Updated
 - Naming of the Tezos RPC methods

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "4.1.22",
+  "version": "4.1.23",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/dto/shared.dto.ts
+++ b/src/dto/shared.dto.ts
@@ -16,7 +16,7 @@ export interface TokenIdContractAddress extends TokenAddress {
   tokenId: string
 }
 
-export interface AddressBalanceDetails extends AddressBalanceFilters {
+interface Pagination {
   /**
    * Optional page size. If not specified, the default page size is used, which is 10.
    */
@@ -27,7 +27,7 @@ export interface AddressBalanceDetails extends AddressBalanceFilters {
   page?: number
 }
 
-export interface AddressBalanceFilters {
+export interface AddressBalanceFilters extends Pagination {
   /**
    * List of addresses to check.
    */
@@ -39,6 +39,18 @@ export interface AddressBalanceFiltersTron {
    * Address to check.
    */
   address: string
+}
+
+export interface AddressBalanceFiltersTezos extends Pagination {
+  /**
+   * Address to check.
+   */
+  address: string
+
+  /**
+   * Optional filter for token types. If not specified, all token types are returned. Allowed values are `fungible`, `nft` and `multitoken`.
+   */
+  tokenTypes?: string[]
 }
 
 export interface TokenDetails {

--- a/src/e2e/tatum.address.spec.ts
+++ b/src/e2e/tatum.address.spec.ts
@@ -258,39 +258,24 @@ describe.skip('Address', () => {
         })
       })
 
-      it('should get balance with native assets only', async () => {
-        const { data } = await tatum.address.getBalance({
-          addresses: ['tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk'],
-        })
-        expect(data).toHaveLength(1)
+      it('should get all balances for address', async () => {
+        const { data } = await tatum.address.getBalance({ address: 'tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk' })
+        expect(data.length).toBeGreaterThan(1)
         expect(data[0]).toStrictEqual({
           asset: 'XTZ',
-          decimals: 6,
           address: 'tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk',
           balance: expect.any(String),
           type: 'native',
         })
       })
 
-      it('should get balance with native assets only for 2 addresses', async () => {
+      it('should get balance for nft tokens only', async () => {
         const { data } = await tatum.address.getBalance({
-          addresses: ['tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk', 'tz1YkqJKPWXjREzs9L32AZqe3yiEdfhSYx3x'],
-        })
-        expect(data).toHaveLength(2)
-        expect(data[0]).toStrictEqual({
-          asset: 'XTZ',
           address: 'tz1irJKkXS2DBWkU1NnmFQx1c1L7pbGg4yhk',
-          decimals: 6,
-          balance: expect.any(String),
-          type: 'native',
+          tokenTypes: ['nft'],
         })
-        expect(data[1]).toStrictEqual({
-          asset: 'XTZ',
-          address: 'tz1YkqJKPWXjREzs9L32AZqe3yiEdfhSYx3x',
-          decimals: 6,
-          balance: expect.any(String),
-          type: 'native',
-        })
+        expect(data.length).toBeGreaterThan(1)
+        data.every((token) => expect(token.type).toBe('nft'))
       })
     })
 

--- a/src/service/address/address.dto.ts
+++ b/src/service/address/address.dto.ts
@@ -33,6 +33,16 @@ export interface AddressBalance {
   lastUpdatedBlockNumber?: number
 }
 
+export interface AddressBalanceDataApi {
+  address: string
+  symbol?: string
+  name?: string
+  balance: string
+  type: string
+  tokenAddress?: string
+  tokenId?: string
+}
+
 export interface GetAddressTransactionsQuery {
   /**
    * Blockchain address to get transactions for.

--- a/src/service/nft/nft.ts
+++ b/src/service/nft/nft.ts
@@ -1,7 +1,7 @@
 import { Container, Service } from 'typedi'
 import { ApiBalanceRequest } from '../../api/api.dto'
 import { TatumConnector } from '../../connector/tatum.connector'
-import { AddressBalanceDetails } from '../../dto'
+import { AddressBalanceFilters } from '../../dto'
 import { CONFIG, ErrorUtils, ResponseDto } from '../../util'
 import { Ipfs } from '../ipfs'
 import { TatumConfig } from '../tatum'
@@ -183,7 +183,7 @@ export class Nft {
     page = 0,
     pageSize = 50,
     addresses,
-  }: AddressBalanceDetails): Promise<ResponseDto<NftAddressBalance[]>> {
+  }: AddressBalanceFilters): Promise<ResponseDto<NftAddressBalance[]>> {
     const chain = this.config.network
     return ErrorUtils.tryFail(() =>
       this.connector

--- a/src/service/token/token.ts
+++ b/src/service/token/token.ts
@@ -1,6 +1,6 @@
 import { Container, Service } from 'typedi'
 import { TatumApi } from '../../api/tatum.api'
-import { AddressBalanceDetails, isDataApiEvmEnabledNetwork } from '../../dto'
+import { AddressBalanceFilters, isDataApiEvmEnabledNetwork } from '../../dto'
 import { CONFIG, ErrorUtils, ResponseDto } from '../../util'
 import { TatumConfig } from '../tatum'
 import {
@@ -38,7 +38,7 @@ export class Token {
     page = 0,
     pageSize = 50,
     addresses,
-  }: AddressBalanceDetails): Promise<ResponseDto<FungibleTokenBalance[]>> {
+  }: AddressBalanceFilters): Promise<ResponseDto<FungibleTokenBalance[]>> {
     const chain = this.config.network
     if (isDataApiEvmEnabledNetwork(chain)) {
       return ErrorUtils.tryFail(() =>


### PR DESCRIPTION
Tezos address balances fixes. Call to `address.getBalance` returns balances of all tokens for a given address. This call accepts only one `address` as a parameter, not an array of addresses.
Update filters for this call to accept optional parameters `tokenTypes`, `page` and `pageSize`