### PR TITLE
Tweak dev env detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
+## [4.2.1] - 2024.1.9
+
+### Updated
+
+- Assert development environment if `NODE_ENV` is not set
+
+### Fixed
+
+- Use globalThis instead of `process.env` for setting `TatumDevelopmentLogger`'s `isWelcomeDisabled` flag
+
 ## [4.2.0] - 2024.1.8
 
+### Added
+
 - Added logging support
+
+### Updated
+
 - Updated dependencies
 
 ## [4.1.37] - 2024.1.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/service/logger/logger.development.ts
+++ b/src/service/logger/logger.development.ts
@@ -8,15 +8,15 @@ interface TatumDevelopmentLoggerOptions {
 }
 
 export class TatumDevelopmentLogger implements Logger {
-  private static readonly DISABLE_WELCOME = 'TTM_DISABLE_WELCOME'
+  private static readonly DISABLE_WELCOME = '__TTM_DISABLE_WELCOME__'
   private static isWelcomeDisabled(): boolean {
-    if (!EnvUtils.isProcessAvailable()) return false
-    return process.env[TatumDevelopmentLogger.DISABLE_WELCOME] === 'true'
+    const anyGlobal = globalThis as unknown as { __TTM_DISABLE_WELCOME__: boolean }
+    return !!anyGlobal[TatumDevelopmentLogger.DISABLE_WELCOME]
   }
 
   private static disableWelcome(): void {
-    if (!EnvUtils.isProcessAvailable()) return
-    process.env[TatumDevelopmentLogger.DISABLE_WELCOME] = 'true'
+    const anyGlobal = globalThis as unknown as { __TTM_DISABLE_WELCOME__: boolean }
+    anyGlobal[TatumDevelopmentLogger.DISABLE_WELCOME] = true
   }
 
   private readonly options: TatumDevelopmentLoggerOptions

--- a/src/util/env.ts
+++ b/src/util/env.ts
@@ -2,6 +2,6 @@ export const EnvUtils = {
   isBrowser: () => typeof window !== 'undefined',
   isProcessAvailable: () => typeof process !== 'undefined',
   isDevelopment: () =>
-    (EnvUtils.isProcessAvailable() && process?.env?.NODE_ENV === 'development') ||
+    (EnvUtils.isProcessAvailable() && (!process.env?.NODE_ENV || process.env?.NODE_ENV === 'development')) ||
     (EnvUtils.isBrowser() && ['localhost', '127.0.0.1', '[::1]'].includes(window.location.hostname)),
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,9 +143,9 @@
   integrity sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==
 
 "@babel/helpers@^7.23.7":
-  version "7.23.7"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.7.tgz#eb543c36f81da2873e47b76ee032343ac83bba60"
-  integrity sha512-6AMnjCoC8wjqBzDHkuqpa7jAKwvMo4dC+lr/TFBz+ucfulO1XMpDnwWPGBNwClOKZ8h6xn5N81W/R5OrcKtCbQ==
+  version "7.23.8"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.8.tgz#fc6b2d65b16847fd50adddbd4232c76378959e34"
+  integrity sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==
   dependencies:
     "@babel/template" "^7.22.15"
     "@babel/traverse" "^7.23.7"
@@ -1264,9 +1264,9 @@ dotenv@^16.0.3:
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
 electron-to-chromium@^1.4.601:
-  version "1.4.623"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.623.tgz#0f7400114ac3425500e9244d2b0e9c3107c331cb"
-  integrity sha512-lKoz10iCYlP1WtRYdh5MvocQPWVRoI7ysp6qf18bmeBgR8abE6+I2CsfyNKztRDZvhdWc+krKT6wS7Neg8sw3A==
+  version "1.4.625"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz#a9a1d18ee911f9074a9c42d9e84b1c79b29f4059"
+  integrity sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==
 
 emittery@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
# Description

Assert development environment if `NODE_ENV` is not set. Also changes `TatumDevelopmentLogger` to use globalThis instead of `process.env` for setting `isWelcomeDisabled` flag, so it can be safely used in most environments.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
