### PR TITLE
ALL-4863: doge getblock verbose param should be boolean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 coverage
 *.log
 .env
+jest-junit.xml

--- a/src/dto/rpc/UtxoBasedRpcSuite.ts
+++ b/src/dto/rpc/UtxoBasedRpcSuite.ts
@@ -3,12 +3,19 @@
 import { JsonRpcResponse } from '../JsonRpcResponse.dto'
 import { AbstractRpcInterface } from './AbstractJsonRpcInterface'
 
+export interface UtxoBasedCommonRpcSuite extends UtxoBasedRpcSuite {
+  getBlock(hashOrHeight: string, verbose?: 0 | 1 | 2): Promise<JsonRpcResponse<any>>
+}
+
+export interface DogeRpcSuite extends UtxoBasedRpcSuite {
+  getBlock(hashOrHeight: string, verbose?: boolean): Promise<JsonRpcResponse<any>>
+}
+
 export interface UtxoBasedRpcSuite extends UtxoBasedRpcInterface, AbstractRpcInterface {}
 
 export interface UtxoBasedRpcInterface {
   // blockchain methods
   getBestBlockHash(): Promise<JsonRpcResponse<string>>
-  getBlock(hashOrHeight: string, verbose?: 0 | 1 | 2): Promise<JsonRpcResponse<any>>
   getBlockChainInfo(): Promise<JsonRpcResponse<any>>
   getBlockCount(): Promise<JsonRpcResponse<number>>
   getBlockHash(height: number): Promise<JsonRpcResponse<string>>

--- a/src/e2e/rpc/utxo/tatum.rpc.btc.spec.ts
+++ b/src/e2e/rpc/utxo/tatum.rpc.btc.spec.ts
@@ -1,0 +1,20 @@
+import { Bitcoin, Network } from '../../../service'
+import { UtxoE2eUtils, UtxoNetworkType } from './utxo.e2e.utils'
+
+describe('Bitcoin', () => {
+  describe('mainnet', () => {
+    it('getblock', async () => {
+      const tatum = await UtxoE2eUtils.initTatum<Bitcoin>({
+        network: Network.BITCOIN,
+        type: UtxoNetworkType.MAIN,
+      })
+      const hash: string = '000000000000000000018d552ccb3928f02753dd5b2abe41d593db58c29a4e3f'
+      const response = await tatum.rpc.getBlock(hash, 0)
+
+      expect(response).toBeDefined()
+      expect(typeof response.result).toBe('string')
+
+      await tatum.destroy()
+    })
+  })
+})

--- a/src/e2e/rpc/utxo/tatum.rpc.doge.spec.ts
+++ b/src/e2e/rpc/utxo/tatum.rpc.doge.spec.ts
@@ -1,4 +1,4 @@
-import { Network } from '../../../service'
+import { Dogecoin, Network } from '../../../service'
 import { UtxoE2eUtils, UtxoNetworkType } from './utxo.e2e.utils'
 
 describe('Doge', () => {
@@ -18,6 +18,32 @@ describe('Doge', () => {
       )
 
       expect(result.result).not.toBeNull()
+      await tatum.destroy()
+    })
+    it('getblock', async () => {
+      const tatum = await UtxoE2eUtils.initTatum<Dogecoin>({
+        network: Network.DOGECOIN,
+        type: UtxoNetworkType.MAIN,
+      })
+      const hash: string = '4cddee0cb7cc1e7a5d6a099285461e0470b2af8078dae35d5ac77e7c57bbc997'
+      const response1 = await tatum.rpc.getBlock(hash, true)
+
+      expect(response1).toBeDefined()
+      expect(response1.result).toStrictEqual(
+        expect.objectContaining({
+          hash,
+          version: 6422788,
+          height: 5092153,
+          size: 998443,
+          merkleroot: '8918a6f70a0ca3c9b4f745c86a7aa3a3d67d18b9c658eacb571c13d7fed0c7a7',
+          chainwork: '000000000000000000000000000000000000000000000f2239716b279a602583',
+        }),
+      )
+
+      const response2 = await tatum.rpc.getBlock(hash, false)
+      expect(response2).toBeDefined()
+      expect(typeof response2.result).toBe('string')
+
       await tatum.destroy()
     })
   })

--- a/src/service/tatum/tatum.utxo.ts
+++ b/src/service/tatum/tatum.utxo.ts
@@ -1,5 +1,10 @@
 import { Container } from 'typedi'
-import { UtxoBasedRpcSuite, UtxoBasedRpcSuiteEstimateFee } from '../../dto'
+import {
+  DogeRpcSuite,
+  UtxoBasedCommonRpcSuite,
+  UtxoBasedRpcSuite,
+  UtxoBasedRpcSuiteEstimateFee,
+} from '../../dto'
 import { CONFIG, Utils } from '../../util'
 import { Address } from '../address'
 import { FeeUtxo } from '../fee'
@@ -46,9 +51,17 @@ export abstract class FullUtxo extends NotificationUtxo {
   }
 }
 
-export class Bitcoin extends FullUtxo {}
-export class Litecoin extends FullUtxo {}
-export class Dogecoin extends FullUtxo {}
+export abstract class FullCommonUtxo extends FullUtxo {
+  rpc: UtxoBasedCommonRpcSuite
+
+  constructor(id: string) {
+    super(id)
+    this.rpc = Utils.getRpc<UtxoBasedCommonRpcSuite>(id, Container.of(id).get(CONFIG))
+  }
+}
+
+export class Bitcoin extends FullCommonUtxo {}
+export class Litecoin extends FullCommonUtxo {}
 export class BitcoinCash extends NotificationUtxo {
   rpc: UtxoBasedRpcSuiteEstimateFee
 
@@ -58,3 +71,7 @@ export class BitcoinCash extends NotificationUtxo {
   }
 }
 export class ZCash extends BaseUtxo {}
+
+export class Dogecoin extends FullUtxo {
+  rpc: DogeRpcSuite
+}


### PR DESCRIPTION
# Description

Doge `getBlock` method has different type of `verbosity` param then other UTXO based chains.
See:
https://github.com/dogecoin/dogecoin/blob/3a29ba6d497cd1d0a32ecb039da0d35ea43c9c85/src/rpc/blockchain.cpp#L741

Fixes # (issue)

- ALL-4863

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
