### PR TITLE
Skip gas estimation if already present (ethereum)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "1.37.44",
+  "version": "1.37.45",
   "description": "Tatum API client allows browsers and Node.js clients to interact with Tatum API.",
   "main": "dist/src/index.js",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/transaction/eth.ts
+++ b/src/transaction/eth.ts
@@ -97,9 +97,8 @@ export const signEthKMSTransaction = async (tx: TransactionKMS, fromPrivateKey: 
   }
   const client = getClient(provider, fromPrivateKey);
   const transactionConfig = JSON.parse(tx.serializedTransaction);
-  const gas = await client.eth.estimateGas(transactionConfig);
   if (!transactionConfig.gas) {
-    transactionConfig.gas = gas;
+    transactionConfig.gas = await client.eth.estimateGas(transactionConfig);
   }
   if (!transactionConfig.nonce) {
     transactionConfig.nonce = await ethGetTransactionsCount(client.eth.defaultAccount as string);


### PR DESCRIPTION
# Description

We don't need call `estimateGas` if the gas property already present in the serialized transaction. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
