### PR TITLE
ALL-8523: relax ssrf checks and allow tatum gateway nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.2.40] - 2024.8.25
+
+### Fixed
+
+- Relax SSRF checks and allow tatum gateway nodes
+
 ## [4.2.39] - 2024.8.14
 
 ### Updated
@@ -71,7 +77,6 @@
 
 - Support for Avalanche Notifications
 
-
 ## [4.2.27] - 2024.5.6
 
 ### Added
@@ -81,7 +86,6 @@
 ### Removed
 
 - Polygon Mumbai
-
 
 ## [4.2.26] - 2024.5.6
 
@@ -94,7 +98,6 @@
 ### Added
 
 - Added support for Iota API calls
-
 
 ## [4.2.23] - 2024.4.10
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "4.2.39",
+  "version": "4.2.40",
   "description": "Tatum JS SDK",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/service/rpc/generic/LoadBalancer.ts
+++ b/src/service/rpc/generic/LoadBalancer.ts
@@ -338,7 +338,7 @@ export class LoadBalancer implements AbstractRpcInterface {
   private checkSSRF(url: string): boolean {
     try {
       const parsedUrl = new URL(url)
-      return parsedUrl.hostname.endsWith('rpc.tatum.io')
+      return parsedUrl.hostname.endsWith('tatum.io')
     } catch (e) {
       Utils.log({
         id: this.id,
@@ -358,7 +358,7 @@ export class LoadBalancer implements AbstractRpcInterface {
         return typeMatch
       }
 
-      // If noSSRFCheck is false or undefined, check if the URL ends with 'rpc.tatum.io'.
+      // If noSSRFCheck is false or undefined, check if the URL ends with 'tatum.io'.
       const ssrfCheckPassed = this.checkSSRF(node.url)
 
       // Log if the URL doesn't pass the SSRF check


### PR DESCRIPTION
# Description

Addition of *.gateway.tatum.io nodes caused ssrf checks to fail and nodes being ignored for routing, relax those checks and allow these nodes no be routed to.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
