### PR TITLE
ALL-9443 Renamed Currency.ARB BASE OPTIMISM & Added USDC USDT for ARB BASE OPTIMISM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tatumio",
-  "version": "2.2.87",
+  "version": "2.2.88",
   "license": "MIT",
   "repository": "https://github.com/tatumio/tatum-js",
   "scripts": {

--- a/packages/api-client/src/lib/models/Currency.ts
+++ b/packages/api-client/src/lib/models/Currency.ts
@@ -76,8 +76,8 @@ export enum Currency {
   NEO = 'NEO',
   KLAY = 'KLAY',
   EOS = 'EOS',
-  ARB = 'ARB',
-  OPTIMISM = 'OPTIMISM',
+  ETH_ARB = 'ETH_ARB',
+  ETH_OP = 'ETH_OP',
   NEAR = 'NEAR',
   CRO = 'CRO',
   RSK = 'RSK',
@@ -99,7 +99,7 @@ export enum Currency {
   CHZ = 'CHZ',
   ISLM = 'ISLM',
   FLR = 'FLR',
-  BASE = 'BASE',
+  ETH_BASE = 'ETH_BASE',
   KADENA = 'KADENA',
   ROSTRUM = 'ROSTRUM',
   ATOM = 'ATOM',
@@ -108,6 +108,12 @@ export enum Currency {
   'CSPR' = 'CSPR',
   TON = 'TON',
   ZK_SYNC = 'ZK_SYNC',
+  USDC_ARB = 'USDC_ARB',
+  USDC_OP = 'USDC_OP',
+  USDC_BASE = 'USDC_BASE',
+  USDT_ARB = 'USDT_ARB',
+  USDT_OP = 'USDT_OP',
+  USDT_BASE = 'USDT_BASE',
 }
 
 export const ERC20_CURRENCIES = [
@@ -200,6 +206,15 @@ export const ETH_BASED_CURRENCIES = [Currency.ETH, ...ERC20_CURRENCIES]
 export const MATIC_BASED_CURRENCIES = [Currency.MATIC, ...MATIC20_CURRENCIES]
 
 export const BSC_BASED_CURRENCIES = [Currency.BSC, ...BEP20_CURRENCIES]
+
+export const ARB_CURRENCIES = [Currency.USDC_ARB, Currency.USDT_ARB]
+export const ARB_BASED_CURRENCIES = [Currency.ETH_ARB, ...ARB_CURRENCIES]
+
+export const OPTIMISM_CURRENCIES = [Currency.USDC_OP, Currency.USDT_OP]
+export const OPTIMISM_BASED_CURRENCIES = [Currency.ETH_OP, ...OPTIMISM_CURRENCIES]
+
+export const BASE_CURRENCIES = [Currency.USDC_BASE, Currency.USDT_BASE]
+export const BASE_BASED_CURRENCIES = [Currency.ETH_BASE, ...BASE_CURRENCIES]
 
 export const NFT_SUPPORTED_CURRENCIES = [
   Currency.ETH,

--- a/packages/blockchain/base/src/lib/__tests__/base.nft.spec.ts
+++ b/packages/blockchain/base/src/lib/__tests__/base.nft.spec.ts
@@ -29,7 +29,7 @@ describe.skip('BaseSDK - nft', () => {
     deployNFTSmartContract: [
       api.nftDeployErc721,
       {
-        chain: Currency.BASE,
+        chain: 'BASE',
         name: 'erc721-token',
         symbol: 'erc721-token',
         fromPrivateKey: testData.TESTNET.ERC_721.PRIVATE_KEY,
@@ -38,7 +38,7 @@ describe.skip('BaseSDK - nft', () => {
     mintNFT: [
       api.nftMintErc721,
       {
-        chain: Currency.BASE,
+        chain: 'BASE',
         to: testData.TESTNET.ERC_721?.ADDRESS,
         url: 'https://google.com/',
       },
@@ -46,7 +46,7 @@ describe.skip('BaseSDK - nft', () => {
     transferNFT: [
       api.nftTransferErc721,
       {
-        chain: Currency.BASE,
+        chain: 'BASE',
         to: testData.TESTNET.ERC_721?.ADDRESS,
         contractAddress: testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
         tokenId: 'erc721-token',
@@ -56,7 +56,7 @@ describe.skip('BaseSDK - nft', () => {
     mintMultipleNFTs: [
       api.nftMintMultipleErc721,
       {
-        chain: Currency.BASE,
+        chain: 'BASE',
         to: testData.TESTNET.ERC_721?.ADDRESS,
         tokenId: 'erc721-token',
         minter: testData.TESTNET.ERC_721?.ADDRESS,
@@ -67,7 +67,7 @@ describe.skip('BaseSDK - nft', () => {
     burnNFT: [
       api.nftBurnErc721,
       {
-        chain: Currency.BASE,
+        chain: 'BASE',
         tokenId: 'erc721-token',
         contractAddress: testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
         fromPrivateKey: testData.TESTNET.ERC_721?.PRIVATE_KEY,
@@ -76,7 +76,7 @@ describe.skip('BaseSDK - nft', () => {
     addNFTMinter: [
       api.nftAddMinter,
       {
-        chain: Currency.BASE,
+        chain: 'BASE',
         contractAddress: testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
         minter: testData.TESTNET.ERC_721?.ADDRESS,
         fromPrivateKey: testData.TESTNET.ERC_721?.PRIVATE_KEY,
@@ -84,37 +84,37 @@ describe.skip('BaseSDK - nft', () => {
     ],
     getNFTTransaction: [
       api.nftGetTransactErc721,
-      Currency.BASE,
+      'BASE',
       '0xe6e7340394958674cdf8606936d292f565e4ecc476aaa8b258ec8a141f7c75d7',
     ],
     getNFTTransactionsByToken: [
       api.nftGetTransactionByToken,
-      Currency.BASE,
+      'BASE',
       'erc721-token',
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
       20,
     ],
     getNFTTransactionsByAddress: [
       api.nftGetTransactionByAddress,
-      Currency.BASE,
+      'BASE',
       testData.TESTNET.ERC_721?.ADDRESS,
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
       20,
     ],
     getNFTsByAddress: [
       api.nftGetTokensByAddressErc721,
-      Currency.BASE,
+      'BASE',
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
     ],
     getNFTAccountBalance: [
       api.nftGetBalanceErc721,
-      Currency.BASE,
+      'BASE',
       testData.TESTNET.ERC_721?.ADDRESS,
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
     ],
     getNFTMetadataURI: [
       api.nftGetMetadataErc721,
-      Currency.BASE,
+      'BASE',
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
       'erc721-token',
     ],

--- a/packages/blockchain/optimism/src/lib/__tests__/optimism.nft.spec.ts
+++ b/packages/blockchain/optimism/src/lib/__tests__/optimism.nft.spec.ts
@@ -29,7 +29,7 @@ describe('OptimismSDK - nft', () => {
     deployNFTSmartContract: [
       api.nftDeployErc721,
       {
-        chain: Currency.OPTIMISM,
+        chain: 'OPTIMISM',
         name: 'erc721-token',
         symbol: 'erc721-token',
         fromPrivateKey: testData.TESTNET.ERC_721.PRIVATE_KEY,
@@ -38,7 +38,7 @@ describe('OptimismSDK - nft', () => {
     mintNFT: [
       api.nftMintErc721,
       {
-        chain: Currency.OPTIMISM,
+        chain: 'OPTIMISM',
         to: testData.TESTNET.ERC_721?.ADDRESS,
         url: 'https://google.com/',
       },
@@ -46,7 +46,7 @@ describe('OptimismSDK - nft', () => {
     transferNFT: [
       api.nftTransferErc721,
       {
-        chain: Currency.OPTIMISM,
+        chain: 'OPTIMISM',
         to: testData.TESTNET.ERC_721?.ADDRESS,
         contractAddress: testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
         tokenId: 'erc721-token',
@@ -56,7 +56,7 @@ describe('OptimismSDK - nft', () => {
     mintMultipleNFTs: [
       api.nftMintMultipleErc721,
       {
-        chain: Currency.OPTIMISM,
+        chain: 'OPTIMISM',
         to: testData.TESTNET.ERC_721?.ADDRESS,
         tokenId: 'erc721-token',
         minter: testData.TESTNET.ERC_721?.ADDRESS,
@@ -67,7 +67,7 @@ describe('OptimismSDK - nft', () => {
     burnNFT: [
       api.nftBurnErc721,
       {
-        chain: Currency.OPTIMISM,
+        chain: 'OPTIMISM',
         tokenId: 'erc721-token',
         contractAddress: testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
         fromPrivateKey: testData.TESTNET.ERC_721?.PRIVATE_KEY,
@@ -76,7 +76,7 @@ describe('OptimismSDK - nft', () => {
     addNFTMinter: [
       api.nftAddMinter,
       {
-        chain: Currency.OPTIMISM,
+        chain: 'OPTIMISM',
         contractAddress: testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
         minter: testData.TESTNET.ERC_721?.ADDRESS,
         fromPrivateKey: testData.TESTNET.ERC_721?.PRIVATE_KEY,
@@ -84,37 +84,37 @@ describe('OptimismSDK - nft', () => {
     ],
     getNFTTransaction: [
       api.nftGetTransactErc721,
-      Currency.OPTIMISM,
+      'OPTIMISM',
       '0xe6e7340394958674cdf8606936d292f565e4ecc476aaa8b258ec8a141f7c75d7',
     ],
     getNFTTransactionsByToken: [
       api.nftGetTransactionByToken,
-      Currency.OPTIMISM,
+      'OPTIMISM',
       'erc721-token',
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
       20,
     ],
     getNFTTransactionsByAddress: [
       api.nftGetTransactionByAddress,
-      Currency.OPTIMISM,
+      'OPTIMISM',
       testData.TESTNET.ERC_721?.ADDRESS,
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
       20,
     ],
     getNFTsByAddress: [
       api.nftGetTokensByAddressErc721,
-      Currency.OPTIMISM,
+      'OPTIMISM',
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
     ],
     getNFTAccountBalance: [
       api.nftGetBalanceErc721,
-      Currency.OPTIMISM,
+      'OPTIMISM',
       testData.TESTNET.ERC_721?.ADDRESS,
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
     ],
     getNFTMetadataURI: [
       api.nftGetMetadataErc721,
-      Currency.OPTIMISM,
+      'OPTIMISM',
       testData.TESTNET.ERC_721?.CONTRACT_ADDRESS,
       'erc721-token',
     ],

--- a/packages/shared/core/src/lib/contract.common.ts
+++ b/packages/shared/core/src/lib/contract.common.ts
@@ -44,6 +44,12 @@ export const CONTRACT_ADDRESSES = {
   [Currency.CAKE.toString()]: '0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82',
   [Currency.BUSD_BSC.toString()]: '0xe9e7cea3dedca5984780bafc599bd69add087d56',
   [Currency.GMC_BSC.toString()]: '0xa6272359bc37f61af398071b65c8934aca744d53',
+  [Currency.USDC_ARB]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+  [Currency.USDT_ARB]: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+  [Currency.USDC_OP]: '0x0b2c639c533813f4aa9d7837caf62653d097ff85',
+  [Currency.USDT_OP]: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
+  [Currency.USDC_BASE]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  [Currency.USDT_BASE]: '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2',
 }
 
 export const CONTRACT_DECIMALS = {
@@ -90,6 +96,12 @@ export const CONTRACT_DECIMALS = {
   [Currency.BXRP.toString()]: 18,
   [Currency.BLTC.toString()]: 18,
   [Currency.BBCH.toString()]: 18,
+  [Currency.USDC_ARB.toString()]: 6,
+  [Currency.USDT_ARB.toString()]: 6,
+  [Currency.USDC_OP.toString()]: 6,
+  [Currency.USDT_OP.toString()]: 6,
+  [Currency.USDC_BASE.toString()]: 6,
+  [Currency.USDT_BASE.toString()]: 6,
 }
 
 export const CUSTODIAL_PROXY_ABI = {

--- a/packages/shared/core/src/lib/contract.common.ts
+++ b/packages/shared/core/src/lib/contract.common.ts
@@ -44,12 +44,12 @@ export const CONTRACT_ADDRESSES = {
   [Currency.CAKE.toString()]: '0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82',
   [Currency.BUSD_BSC.toString()]: '0xe9e7cea3dedca5984780bafc599bd69add087d56',
   [Currency.GMC_BSC.toString()]: '0xa6272359bc37f61af398071b65c8934aca744d53',
-  [Currency.USDC_ARB]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-  [Currency.USDT_ARB]: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
-  [Currency.USDC_OP]: '0x0b2c639c533813f4aa9d7837caf62653d097ff85',
-  [Currency.USDT_OP]: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
-  [Currency.USDC_BASE]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-  [Currency.USDT_BASE]: '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2',
+  [Currency.USDC_ARB.toString()]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+  [Currency.USDT_ARB.toString()]: '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+  [Currency.USDC_OP.toString()]: '0x0b2c639c533813f4aa9d7837caf62653d097ff85',
+  [Currency.USDT_OP.toString()]: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
+  [Currency.USDC_BASE.toString()]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  [Currency.USDT_BASE.toString()]: '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2',
 }
 
 export const CONTRACT_DECIMALS = {

--- a/packages/shared/core/src/lib/models/BlockchainCurrencyMapping.ts
+++ b/packages/shared/core/src/lib/models/BlockchainCurrencyMapping.ts
@@ -1,4 +1,5 @@
 import {
+  BASE_BASED_CURRENCIES,
   BSC_BASED_CURRENCIES,
   CELO_CURRENCIES,
   Currency,
@@ -6,6 +7,7 @@ import {
   FLOW_CURRENCIES,
   MATIC_BASED_CURRENCIES,
   NativeCurrency,
+  OPTIMISM_BASED_CURRENCIES,
   TRON_CURRENCIES,
 } from '@tatumio/api-client'
 import { Blockchain } from './Blockchain'
@@ -60,9 +62,15 @@ export const BlockchainCurrencyMapping: Record<
   CHILIZ: Currency.CHZ,
   FLR: Currency.FLR,
   CRO: Currency.CRO,
-  BASE: Currency.BASE,
+  BASE: {
+    nativeCurrency: Currency.ETH_BASE,
+    currencies: BASE_BASED_CURRENCIES,
+  },
   AVAX: Currency.AVAX,
-  OPTIMISM: Currency.OPTIMISM,
+  OPTIMISM: {
+    nativeCurrency: Currency.ETH_OP,
+    currencies: OPTIMISM_BASED_CURRENCIES
+  },
   FTM: Currency.FTM,
   TON: Currency.TON,
   ZK_SYNC: Currency.ZK_SYNC,


### PR DESCRIPTION


# Description

Rename existing currencies ARB & BASE & OPTIMISM to ETH_ARB & ETH_BASE & ETH_OP
Add new currencies USDC_ARB, USDT_ARB, USDC_BASE, USDT_BASE, USDC_OP, USDT_OP

Fixes # (issue)

Fix BASE and OPTIMISM unit tests, where Currency was passed instead of chain and now currency has different string value and does not match chain.

