### PR TITLE
ALL-9443 Rename Currency.ARB BASE OPTIMISM & Added USDC USDT for ARB …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "1.37.55",
+  "version": "1.37.56",
   "description": "Tatum API client allows browsers and Node.js clients to interact with Tatum API.",
   "main": "dist/src/index.js",
   "repository": "https://github.com/tatumio/tatum-js",

--- a/src/model/request/Currency.ts
+++ b/src/model/request/Currency.ts
@@ -81,8 +81,8 @@ export enum Currency {
   EOS = 'EOS',
   AVAX = 'AVAX',
   FTM = 'FTM',
-  ARB = 'ARB',
-  OPTIMISM = 'OPTIMISM',
+  ETH_ARB = 'ETH_ARB',
+  ETH_OP = 'ETH_OP',
   NEAR = 'NEAR',
   CRO = 'CRO',
   RSK = 'RSK',
@@ -99,7 +99,7 @@ export enum Currency {
   CHZ = 'CHZ',
   ISLM = 'ISLM',
   FLR = 'FLR',
-  BASE = 'BASE',
+  ETH_BASE = 'ETH_BASE',
   KADENA = 'KADENA',
   ROSTRUM = 'ROSTRUM',
   ATOM = 'ATOM',
@@ -108,6 +108,12 @@ export enum Currency {
   CSPR = 'CSPR',
   TON = 'TON',
   ZK_SYNC = 'ZK_SYNC',
+  USDC_ARB = 'USDC_ARB',
+  USDC_OP = 'USDC_OP',
+  USDC_BASE = 'USDC_BASE',
+  USDT_ARB = 'USDT_ARB',
+  USDT_OP = 'USDT_OP',
+  USDT_BASE = 'USDT_BASE',
 }
 
 export const ERC20_CURRENCIES = [
@@ -170,3 +176,12 @@ export const ETH_BASED_CURRENCIES = [Currency.ETH.toString(), ...ERC20_CURRENCIE
 export const MATIC_BASED_CURRENCIES = [Currency.MATIC.toString(), ...MATIC20_CURRENCIES]
 
 export const BSC_BASED_CURRENCIES = [Currency.BSC.toString(), ...BEP20_CURRENCIES]
+
+export const ARB_CURRENCIES = [Currency.USDC_ARB.toString(), Currency.USDT_ARB.toString()]
+export const ARB_BASED_CURRENCIES = [Currency.ETH_ARB.toString(), ...ARB_CURRENCIES]
+
+export const OPTIMISM_CURRENCIES = [Currency.USDC_OP.toString(), Currency.USDT_OP.toString()]
+export const OPTIMISM_BASED_CURRENCIES = [Currency.ETH_OP.toString(), ...OPTIMISM_CURRENCIES]
+
+export const BASE_CURRENCIES = [Currency.USDC_BASE.toString(), Currency.USDT_BASE.toString()]
+export const BASE_BASED_CURRENCIES = [Currency.ETH_BASE.toString(), ...BASE_CURRENCIES]

--- a/src/model/request/TransferErc20.ts
+++ b/src/model/request/TransferErc20.ts
@@ -12,7 +12,7 @@ import {
     ValidateIf,
     ValidateNested,
 } from 'class-validator';
-import { BSC_BASED_CURRENCIES, Currency, ETH_BASED_CURRENCIES, MATIC_BASED_CURRENCIES } from './Currency';
+import { ARB_BASED_CURRENCIES, BASE_BASED_CURRENCIES, BSC_BASED_CURRENCIES, Currency, ETH_BASED_CURRENCIES, MATIC_BASED_CURRENCIES, OPTIMISM_BASED_CURRENCIES } from './Currency';
 import { Fee } from './Fee';
 import { PrivateKeyOrSignatureId } from './PrivateKeyOrSignatureId';
 import { OneOf } from '../validation/OneOf'
@@ -34,7 +34,7 @@ export class TransferErc20 extends PrivateKeyOrSignatureId {
   public data?: string;
 
   @IsOptional()
-  @IsIn([...ETH_BASED_CURRENCIES, ...MATIC_BASED_CURRENCIES, Currency.XDC, Currency.KLAY, Currency.ONE, ...BSC_BASED_CURRENCIES, Currency.ALGO])
+  @IsIn([...ETH_BASED_CURRENCIES, ...MATIC_BASED_CURRENCIES, Currency.XDC, Currency.KLAY, Currency.ONE, ...BSC_BASED_CURRENCIES, Currency.ALGO, ...ARB_BASED_CURRENCIES, ...BASE_BASED_CURRENCIES, ...OPTIMISM_BASED_CURRENCIES])
   public currency?: Currency;
 
   @OneOf(['currency', 'contractAddress'])

--- a/src/wallet/address.ts
+++ b/src/wallet/address.ts
@@ -788,6 +788,15 @@ export const generateAddressFromXPub = (
     case Currency.BLTC:
     case Currency.BBCH:
     case Currency.MMY:
+    case Currency.ETH_ARB:
+    case Currency.ETH_BASE:
+    case Currency.ETH_OP:
+    case Currency.USDC_ARB:
+    case Currency.USDT_ARB:
+    case Currency.USDC_BASE:
+    case Currency.USDT_BASE:
+    case Currency.USDC_OP:
+    case Currency.USDT_OP:
       return generateEthAddress(testnet, xpub, i);
     case Currency.ONE:
       return generateOneAddress(testnet, xpub, i);
@@ -888,6 +897,15 @@ export const generatePrivateKeyFromMnemonic = (
     case Currency.BLTC:
     case Currency.BBCH:
     case Currency.MMY:
+    case Currency.ETH_ARB:
+    case Currency.ETH_BASE:
+    case Currency.ETH_OP:
+    case Currency.USDC_ARB:
+    case Currency.USDT_ARB:
+    case Currency.USDC_BASE:
+    case Currency.USDT_BASE:
+    case Currency.USDC_OP:
+    case Currency.USDT_OP:
       return generateEthPrivateKey(testnet, mnemonic, i);
     case Currency.ONE:
       return generateOnePrivateKey(testnet, mnemonic, i);
@@ -955,7 +973,15 @@ export const generateAddressFromPrivatekey = (
     case Currency.MMY:
     case Currency.MATIC:
     case Currency.KLAY:
-    case Currency.BASE:
+    case Currency.ETH_ARB:
+    case Currency.ETH_BASE:
+    case Currency.ETH_OP:
+    case Currency.USDC_ARB:
+    case Currency.USDT_ARB:
+    case Currency.USDC_BASE:
+    case Currency.USDT_BASE:
+    case Currency.USDC_OP:
+    case Currency.USDT_OP:
       return convertEthPrivateKey(testnet, privateKey);
     case Currency.ONE:
       return convertOnePrivateKey(testnet, privateKey);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -389,6 +389,15 @@ export const generateWallet = (currency: Currency, testnet: boolean, mnemonic?: 
     case Currency.BLTC:
     case Currency.BBCH:
     case Currency.MMY:
+    case Currency.ETH_ARB:
+    case Currency.ETH_BASE:
+    case Currency.ETH_OP:
+    case Currency.USDC_ARB:
+    case Currency.USDT_ARB:
+    case Currency.USDC_BASE:
+    case Currency.USDT_BASE:
+    case Currency.USDC_OP:
+    case Currency.USDT_OP:
       return generateEthWallet(testnet, mnem)
     case Currency.MATIC:
     case Currency.USDC_MATIC:


### PR DESCRIPTION
Rename existing currencies ARB & BASE & OPTIMISM to ETH_ARB & ETH_BASE & ETH_OP
Add new currencies USDC_ARB, USDT_ARB, USDC_BASE, USDT_BASE, USDC_OP, USDT_OP

Fixes # (issue)

Fix BASE and OPTIMISM unit tests, where Currency was passed instead of chain and now currency has different string value and does not match chain.