### PR TITLE
ALL-4487: update 'bitcore-lib' for bitcoin taproot address support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tatumio",
-  "version": "2.2.97",
+  "version": "2.2.98",
   "license": "MIT",
   "repository": "https://github.com/tatumio/tatum-js",
   "scripts": {
@@ -59,7 +59,7 @@
     "bip32": "^2.0.5",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.2.0",
-    "bitcore-lib": "10.0.2",
+    "bitcore-lib": "10.8.0",
     "bitcore-lib-doge": "10.0.0",
     "bitcore-lib-ltc": "10.0.0",
     "bn.js": "^5.2.1",

--- a/tools/patches/bitcore-lib+10.8.0.patch
+++ b/tools/patches/bitcore-lib+10.8.0.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/bitcore-lib/lib/transaction/transaction.js b/node_modu
 index 3d61478..d131e06 100644
 --- a/node_modules/bitcore-lib/lib/transaction/transaction.js
 +++ b/node_modules/bitcore-lib/lib/transaction/transaction.js
-@@ -184,8 +184,6 @@ Transaction.prototype.uncheckedSerialize = Transaction.prototype.toString = func
+@@ -210,8 +210,6 @@ Transaction.prototype.uncheckedSerialize = Transaction.prototype.toString = func
  Transaction.prototype.checkedSerialize = function(opts) {
    var serializationError = this.getSerializationError(opts);
    if (serializationError) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4677,7 +4677,7 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bigi@^1.1.0, bigi@^1.4.0, bigi@^1.4.2:
+bigi@^1.1.0, bigi@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
   integrity sha512-ddkU+dFIuEIW8lE7ZwdIAf2UPoM90eaprg5m3YXAVVTmKlqV/9BX4A2M8BOK2yOq6/VgZFVhK6QAxJebhlbhzw==
@@ -4740,17 +4740,6 @@ bindings@^1.3.0, bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-bip-schnorr@=0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/bip-schnorr/-/bip-schnorr-0.6.4.tgz#6fde7f301fe6b207dbd05f8ec2caf08fa5a51d0d"
-  integrity sha512-dNKw7Lea8B0wMIN4OjEmOk/Z5qUGqoPDY0P2QttLqGk1hmDPytLWW8PR5Pb6Vxy6CprcdEgfJpOjUu+ONQveyg==
-  dependencies:
-    bigi "^1.4.2"
-    ecurve "^1.0.6"
-    js-sha256 "^0.9.0"
-    randombytes "^2.1.0"
-    safe-buffer "^5.2.1"
 
 bip174@^2.0.1:
   version "2.1.0"
@@ -4885,13 +4874,12 @@ bitcore-lib-ltc@10.0.0:
     lodash "^4.17.20"
     scryptsy "2.1.0"
 
-bitcore-lib@10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-10.0.2.tgz#7ba3a90e014584933893a7f8facebf9b9ce5e953"
-  integrity sha512-x7bWAqZdk5B/aVM8ppcenErhjQ2Q8q+SIwqNkB+iKPDsYUCgx7Yvl2SCyQriU23HEJlfqkzBdsFm6tO0DbCikw==
+bitcore-lib@10.8.0:
+  version "10.8.0"
+  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-10.8.0.tgz#e4bffa5da15c6ba77359babad0406729b8405a65"
+  integrity sha512-E3J8+Qs+ATYJdOd5VfJlWuWN3zd7icJUHOW01bbYmrDnBoH/aJzfgkO66fAnNxYdf4m+Uir5sr+lLvzYEgwTKg==
   dependencies:
     bech32 "=2.0.0"
-    bip-schnorr "=0.6.4"
     bn.js "=4.11.8"
     bs58 "^4.0.1"
     buffer-compare "=1.1.1"
@@ -6522,7 +6510,7 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ecurve@^1.0.0, ecurve@^1.0.6:
+ecurve@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/ecurve/-/ecurve-1.0.6.tgz#dfdabbb7149f8d8b78816be5a7d5b83fcf6de797"
   integrity sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==


### PR DESCRIPTION
# Description
Updated the `bitcore-lib` library to enable support for the bitcoin taproot addresses.
