### PR TITLE
ALL-4487: update 'bitcore-lib' for bitcoin taproot address support (v1 branch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum",
-  "version": "1.37.64",
+  "version": "1.37.65",
   "description": "Tatum API client allows browsers and Node.js clients to interact with Tatum API.",
   "main": "dist/src/index.js",
   "repository": "https://github.com/tatumio/tatum-js",
@@ -52,7 +52,7 @@
     "bip32": "^2.0.5",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.2.0",
-    "bitcore-lib": "10.0.2",
+    "bitcore-lib": "10.8.0",
     "bitcore-lib-doge": "10.0.0",
     "bitcore-lib-ltc": "10.0.0",
     "bn.js": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,7 +2702,7 @@ big-integer@^1.6.17, big-integer@^1.6.48:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
 
-bigi@^1.1.0, bigi@^1.4.0, bigi@^1.4.2:
+bigi@^1.1.0, bigi@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
   integrity sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU=
@@ -2751,17 +2751,6 @@ bindings@^1.3.0, bindings@^1.4.0, bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-bip-schnorr@=0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/bip-schnorr/-/bip-schnorr-0.6.4.tgz#6fde7f301fe6b207dbd05f8ec2caf08fa5a51d0d"
-  integrity sha512-dNKw7Lea8B0wMIN4OjEmOk/Z5qUGqoPDY0P2QttLqGk1hmDPytLWW8PR5Pb6Vxy6CprcdEgfJpOjUu+ONQveyg==
-  dependencies:
-    bigi "^1.4.2"
-    ecurve "^1.0.6"
-    js-sha256 "^0.9.0"
-    randombytes "^2.1.0"
-    safe-buffer "^5.2.1"
 
 bip174@^2.0.1:
   version "2.0.1"
@@ -2877,13 +2866,12 @@ bitcore-lib-ltc@10.0.0:
     lodash "^4.17.20"
     scryptsy "2.1.0"
 
-bitcore-lib@10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-10.0.2.tgz#7ba3a90e014584933893a7f8facebf9b9ce5e953"
-  integrity sha512-x7bWAqZdk5B/aVM8ppcenErhjQ2Q8q+SIwqNkB+iKPDsYUCgx7Yvl2SCyQriU23HEJlfqkzBdsFm6tO0DbCikw==
+bitcore-lib@10.8.0:
+  version "10.8.0"
+  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-10.8.0.tgz#e4bffa5da15c6ba77359babad0406729b8405a65"
+  integrity sha512-E3J8+Qs+ATYJdOd5VfJlWuWN3zd7icJUHOW01bbYmrDnBoH/aJzfgkO66fAnNxYdf4m+Uir5sr+lLvzYEgwTKg==
   dependencies:
     bech32 "=2.0.0"
-    bip-schnorr "=0.6.4"
     bn.js "=4.11.8"
     bs58 "^4.0.1"
     buffer-compare "=1.1.1"
@@ -4116,7 +4104,7 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-ecurve@^1.0.0, ecurve@^1.0.6:
+ecurve@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/ecurve/-/ecurve-1.0.6.tgz#dfdabbb7149f8d8b78816be5a7d5b83fcf6de797"
   integrity sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==


### PR DESCRIPTION
# Description
Updated the `bitcore-lib` library to enable support for the bitcoin taproot addresses.
