### PR TITLE
fix: add missing npm metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
     "tslib": "^2.5.0",
     "typescript": "^5.0.4",
     "undici": "^5.28.3"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/tatumio/tatum-js/issues"
+  },
+  "homepage": "https://github.com/tatumio/tatum-js#readme"
 }


### PR DESCRIPTION
Adds missing npm metadata fields to improve package discoverability.